### PR TITLE
Change Styles in the components used in the Delete Confirmation Modal

### DIFF
--- a/components/src/core/components/Button/_variables.scss
+++ b/components/src/core/components/Button/_variables.scss
@@ -225,7 +225,7 @@ $oxd-button-color--label-danger-pressed: rgba(
   $oxd-feedback-danger-color,
   0.2
 ) !default;
-$oxd-button-color--label-danger-hover: rgba($oxd-button-font-color--label-danger, 0.15) !default;
+$oxd-button-color--label-danger-hover: $oxd-button-font-color--label-danger !default;
 $oxd-button-color--label-danger-focus: $oxd-button-color--label-danger-hover !default;
 $oxd-button-color--label-danger-inactive: $oxd-interface-gray-lighten-1-color !default;
 

--- a/components/src/core/components/Button/button.scss
+++ b/components/src/core/components/Button/button.scss
@@ -118,6 +118,8 @@
 .oxd-button-icon {
   color: inherit;
   vertical-align: bottom;
+  position: relative;
+  left: -0.5rem;
 }
 
 .oxd-button--glass {

--- a/components/src/core/components/Dialog/_variables.scss
+++ b/components/src/core/components/Dialog/_variables.scss
@@ -1,7 +1,7 @@
 $oxd-overlay-background-color: rgba($oxd-black-color, 0.5) !default;
 
 $oxd-dialog-close-button-font-color: $oxd-white-color !default;
-$oxd-dialog-close-button-bg-color: $oxd-interface-gray-lighten-1-color !default;
+$oxd-dialog-close-button-bg-color: $oxd-background-gray-color !default;
 $oxd-dialog-close-button-bg-color-hover: $oxd-interface-gray-darken-1-color !default;
 $oxd-dialog-close-button-border-radius: 2.5rem !default;
 $oxd-dialog-close-button-font-size: 1.1rem !default;

--- a/components/src/core/components/Dialog/close-button.scss
+++ b/components/src/core/components/Dialog/close-button.scss
@@ -17,9 +17,9 @@
   font-size: $oxd-dialog-close-button-font-size;
   font-weight: $oxd-dialog-close-button-font-weight;
   border-radius: $oxd-dialog-close-button-border-radius;
-  background-color: $oxd-interface-gray-lighten-1-color;
+  background-color: $oxd-dialog-close-button-bg-color;
 
   &:hover {
-    background-color: $oxd-interface-gray-darken-1-color;
+    background-color: $oxd-dialog-close-button-bg-color-hover;
   }
 }

--- a/components/src/core/components/Text/_variables.scss
+++ b/components/src/core/components/Text/_variables.scss
@@ -46,6 +46,11 @@ $oxd-text-card-title-font-weight: 700 !default;
 $oxd-text-card-title-letter-spacing: 0.15px !default;
 $oxd-text-card-title-color: $oxd-text-color !default;
 
+$oxd-text-modal-title-font-size: 16px !default;
+$oxd-text-modal-title-font-weight: 600 !default;
+$oxd-text-modal-title-letter-spacing: 0.15px !default;
+$oxd-text-modal-title-color: $oxd-text-color !default;
+
 $oxd-text-toast-title-font-size: 14px !default;
 $oxd-text-toast-title-font-weight: 600 !default;
 $oxd-text-toast-title-letter-spacing: 0.15px !default;

--- a/components/src/core/components/Text/text.scss
+++ b/components/src/core/components/Text/text.scss
@@ -69,6 +69,13 @@
     color: $oxd-text-card-title-color;
   }
 
+  &--modal-title {
+    font-size: $oxd-text-modal-title-font-size;
+    font-weight: $oxd-text-modal-title-font-weight;
+    letter-spacing: $oxd-text-modal-title-letter-spacing;
+    color: $oxd-text-modal-title-color;
+  }
+
   &--toast-title {
     font-size: $oxd-text-toast-title-font-size;
     font-weight: $oxd-text-toast-title-font-weight;

--- a/components/src/styles/_colors.scss
+++ b/components/src/styles/_colors.scss
@@ -18,6 +18,7 @@ $oxd-interface-gray-lighten-3-color: #dee2e6 !default;
 $oxd-interface-gray-lighten-4-color: #efefef !default;
 
 /* OXD - Background & Overly Colors */
+$oxd-background-gray-color: #b8bdc7 !default;
 $oxd-background-light-gray-color: #f1f2f5 !default;
 $oxd-background-pastel-white-color: #f6f5fb !default;
 $oxd-background-white-shadow-color: #fafafc !default;

--- a/storybook/stories/core/components/Dialog/DialogDeleteConfirmation.story.vue
+++ b/storybook/stories/core/components/Dialog/DialogDeleteConfirmation.story.vue
@@ -3,7 +3,7 @@
 
   <oxd-dialog v-if="show" @update:show="onCancel" :style="{maxWidth: '450px'}">
     <div class="orangehrm-modal-header">
-      <oxd-text type="card-title">Are you sure?</oxd-text>
+      <oxd-text type="modal-title">Are you sure?</oxd-text>
     </div>
     <div class="orangehrm-text-center-align">
       <oxd-text type="subtitle-2">


### PR DESCRIPTION
1. Confirmation Modal's font weight is changed to 600 (as per the oxd guide)
2. Modal close button's background color is changed to #B8BDC7 (to be consistent with the other places in the prodcut)
3. Hover background color in the danger button is corrected
4. space between the icon and the button text is increased to 0.5rem in icon buttons