### PR TITLE
ENT - RMP-339 Hide icon button tooltip when button is disabled

### DIFF
--- a/components/src/core/components/Button/Icon.vue
+++ b/components/src/core/components/Button/Icon.vue
@@ -5,7 +5,7 @@
     type="button"
     :class="classes"
     @click="onClick"
-    :tooltip="tooltip"
+    :tooltip="tooltipText"
     :flow="flow"
   >
     <oxd-icon :style="iconStyles" :class="{'--disabled': disabled}" :name="name" />
@@ -60,6 +60,10 @@ export default defineComponent({
     iconStyles: {
       type: Object,
       default: () => ({})
+    },
+    showTooltipWhenDisabled: {
+      type: Boolean,
+      default: false,
     }
   },
 
@@ -71,6 +75,9 @@ export default defineComponent({
         'oxd-icon-button': true,
       };
     },
+    tooltipText() {
+      return this.disabled && !this.showTooltipWhenDisabled ? null : this.tooltip;
+    }
   },
 
   methods: {

--- a/components/src/core/components/Button/__tests__/icon-button.spec.ts
+++ b/components/src/core/components/Button/__tests__/icon-button.spec.ts
@@ -15,4 +15,46 @@ describe('Button > Icon.vue', () => {
     });
     expect(wrapper.html()).toMatchSnapshot();
   });
+
+  it('should not render disabled attribute when disabled is not specified', () => {
+    const wrapper = mount(IconButton, {
+      props: {name: 'trash'}
+    });
+    expect(wrapper.attributes('disabled')).toBeUndefined();
+  });
+
+  it('should not render disabled attribute when disabled is false', () => {
+    const wrapper = mount(IconButton, {
+      props: {name: 'trash', disabled: false}
+    });
+    expect(wrapper.attributes('disabled')).toBeUndefined();
+  });
+
+  it('should render disabled attribute when disabled is true', () => {
+    const wrapper = mount(IconButton, {
+      props: {name: 'trash', disabled: true}
+    });
+    expect(wrapper.attributes('disabled')).toBe('');
+  });
+
+  it('should render tooltip attribute when tooltip is given', () => {
+    const wrapper = mount(IconButton, {
+      props: {name: 'trash', tooltip: 'My Tooltip'}
+    });
+    expect(wrapper.attributes('tooltip')).toBe('My Tooltip');
+  });
+
+  it('should not render tooltip attribute when button is disabled', () => {
+    const wrapper = mount(IconButton, {
+      props: {name: 'trash', tooltip: 'My Tooltip', disabled: true}
+    });
+    expect(wrapper.attributes('tooltip')).toBeUndefined();
+  });
+
+  it('should render tooltip attribute when button is disabled if showTooltipWhenDisabled is true', () => {
+    const wrapper = mount(IconButton, {
+      props: {name: 'trash', tooltip: 'My Tooltip', disabled: true, showTooltipWhenDisabled: true}
+    });
+    expect(wrapper.attributes('tooltip')).toBe('My Tooltip');
+  });
 });

--- a/components/src/core/components/TableSidebar/__tests__/__snapshots__/TableSidebar.spec.ts.snap
+++ b/components/src/core/components/TableSidebar/__tests__/__snapshots__/TableSidebar.spec.ts.snap
@@ -29,7 +29,7 @@ exports[`TableSidebar.vue with oxd-chip on left renders OXD TableSidebar  with c
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -41,7 +41,7 @@ exports[`TableSidebar.vue with oxd-chip on left renders OXD TableSidebar  with c
   </div>
   <div class="body"></div>
   <!--v-if-->
-  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -77,7 +77,7 @@ exports[`TableSidebar.vue with oxd-chip on left renders OXD TableSidebar with ch
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -113,7 +113,7 @@ exports[`TableSidebar.vue with oxd-chip on left renders OXD TableSidebar with ch
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -127,7 +127,7 @@ exports[`TableSidebar.vue with oxd-chip on left renders OXD TableSidebar with ch
   <div class="oxd-footer list">
     <ul></ul>
   </div>
-  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -163,7 +163,7 @@ exports[`TableSidebar.vue with oxd-chip on left renders OXD TableSidebar with ch
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -196,7 +196,7 @@ exports[`TableSidebar.vue with oxd-icon on left renders OXD TableSidebar  with i
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -208,7 +208,7 @@ exports[`TableSidebar.vue with oxd-icon on left renders OXD TableSidebar  with i
   </div>
   <div class="body"></div>
   <!--v-if-->
-  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -244,7 +244,7 @@ exports[`TableSidebar.vue with oxd-icon on left renders OXD TableSidebar with ic
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -280,7 +280,7 @@ exports[`TableSidebar.vue with oxd-icon on left renders OXD TableSidebar with ic
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -294,7 +294,7 @@ exports[`TableSidebar.vue with oxd-icon on left renders OXD TableSidebar with ic
   <div class="oxd-footer list">
     <ul></ul>
   </div>
-  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -330,6 +330,6 @@ exports[`TableSidebar.vue with oxd-icon on left renders OXD TableSidebar with ic
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="chevron-left" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel-toggle-btn"></oxd-icon-button-stub>
 </div>
 `;


### PR DESCRIPTION
This PR Contains

1. Hide tooltip when button is disabled
2. New property to override the above behavior (showTooltipWhenDisabled)

This is based on Mike's feedback that disabled buttons should not have a tooltip, but that there can be exceptions where it is needed.