### PR TITLE
ENT - Remove border from checked checkbox to match OXD guidelines.

### DIFF
--- a/components/src/core/components/Input/checkbox-input.scss
+++ b/components/src/core/components/Input/checkbox-input.scss
@@ -30,6 +30,7 @@
 
       &:checked + .oxd-checkbox-input {
         background-color: $oxd-checkbox-checked-background-color;
+        border: none;
         .oxd-checkbox-input-icon {
           opacity: 1;
         }


### PR DESCRIPTION
Checkbox should not have a border when checked according to [OXD Guidelines](https://oxd-prod-infinity.orangehrm.com/pages/check-box.html).