### PR TITLE
ENT- RMP-200 - fix checkbox border radius, and checkbox size

### DIFF
--- a/components/src/core/components/Input/_variables.scss
+++ b/components/src/core/components/Input/_variables.scss
@@ -25,9 +25,10 @@ $oxd-checkbox-check-font-size: 1rem !default;
 $oxd-checkbox-height: 1rem !default;
 $oxd-checkbox-width: 1rem !default;
 $oxd-checkbox-border: 1px solid $oxd-interface-gray-lighten-1-color !default;
-$oxd-checkbox-border-radius: 0.35rem !default;
+$oxd-checkbox-border-radius: 0.25rem !default;
 $oxd-checkbox-label-margin: 0.5em !default;
 $oxd-checkbox-checked-background-color: $oxd-primary-input-color !default;
+$oxd-checkbox-checked-border: 1px solid $oxd-primary-input-color !default;
 $oxd-checkbox-disabled-background-color: $oxd-interface-gray-lighten-2-color !default;
 
 $oxd-switch-label-color: $oxd-input-control-font-color !default;

--- a/components/src/core/components/Input/checkbox-input.scss
+++ b/components/src/core/components/Input/checkbox-input.scss
@@ -30,7 +30,7 @@
 
       &:checked + .oxd-checkbox-input {
         background-color: $oxd-checkbox-checked-background-color;
-        border: none;
+        border: $oxd-checkbox-checked-border;
         .oxd-checkbox-input-icon {
           opacity: 1;
         }


### PR DESCRIPTION
1. Change checkbox border radius to match that in other OXD screens
2. Keep checkbox size same when checked and unchecked. Earlier checkbox was shrinking because there was no border when checked.