### PR TITLE
ENT - Reduced size of table header sort icons to 14px.

### DIFF
--- a/components/src/core/components/CardTable/Table/TableHeaderSortDropdown.vue
+++ b/components/src/core/components/CardTable/Table/TableHeaderSortDropdown.vue
@@ -3,6 +3,7 @@
     <oxd-icon-button
       :withContainer="false"
       :name="sortIcon"
+      size="extra-small"
       class="oxd-table-header-sort-icon"
       tabindex="0"
       @click="openDropdown($event)"
@@ -33,7 +34,7 @@
           @click="$emit('order', 'ASC')"
           @keydown.enter.prevent="$emit('order', 'ASC')"
         >
-          <oxd-icon name="sort-alpha-down" />
+          <oxd-icon name="oxd-sort-asc" size="extra-small"/>
           <oxd-text tag="span">Ascending</oxd-text>
         </li>
         <li
@@ -43,7 +44,7 @@
           @click="$emit('order', 'DESC')"
           @keydown.enter.prevent="$emit('order', 'DESC')"
         >
-          <oxd-icon name="sort-alpha-up" />
+          <oxd-icon name="oxd-sort-desc" size="extra-small"/>
           <oxd-text tag="span">Decending</oxd-text>
         </li>
       </ul>

--- a/components/src/core/components/CardTable/Table/table-header-sort-dropdown.scss
+++ b/components/src/core/components/CardTable/Table/table-header-sort-dropdown.scss
@@ -37,6 +37,7 @@
       color: $oxd-table-sort-dropdown-font-color;
       padding: $oxd-dropdown-padding;
       border-radius: $oxd-dropdown-border-radius;
+      display: flex;
       span {
         margin-left: 5px;
       }


### PR DESCRIPTION
1. Reduced size of table header sort icons to 14px.
2. Changed sort dropdown list icons to match header icons (svg)