### PR TITLE
ENT - RMP-358 "The separator between the left panel and the candidate list is ended in the middle of the list"

### DIFF
--- a/components/src/core/components/List/list.scss
+++ b/components/src/core/components/List/list.scss
@@ -2,12 +2,14 @@
 
 .oxd-list-container {
   margin-top: 2rem;
-  background-color: #fff;
+  background-color: $oxd-white-color;
   border-radius: 1.2rem;
+  padding: 0.5rem;
+  box-sizing: border-box;
   .oxd-table-left-panel {
     &.with-filters {
-      margin-top: 1.25rem;
-      margin-bottom: 1.25rem;
+      margin-top: 0.25rem;
+      margin-bottom: 0.25rem;
     }
   }
   .table-card-list-wrapper {
@@ -15,7 +17,9 @@
     height: 100%;
     border-left: 1px solid $oxd-interface-gray-lighten-4-color;
     .list-table-filter {
-      padding-bottom: 0;
+      padding: 0 0 0 0;
+      margin: 0 0 0 1rem;
+      border-radius: 0;
       :deep(.oxd-table-filter-header) {
         .oxd-table-filter-header-title {
           .oxd-table-filter-title {
@@ -36,7 +40,7 @@
         }
       }
       :deep(.oxd-divider) {
-        margin-top: 0;
+        margin-top: 1rem;
         margin-bottom: 0;
       }
     }

--- a/components/src/core/components/TableFilter/table-filter.scss
+++ b/components/src/core/components/TableFilter/table-filter.scss
@@ -8,7 +8,6 @@
 
   .oxd-table-filter-header {
     display: flex;
-    margin: 0.5rem 0.5rem 1rem 0.5rem;
     align-items: center;
     flex-wrap: wrap;
     justify-content: space-between;

--- a/components/src/core/components/TableSidebar/table-left-panel.scss
+++ b/components/src/core/components/TableSidebar/table-left-panel.scss
@@ -4,7 +4,6 @@
 .oxd-table-left-panel {
   position: relative;
   padding-right: 10px;
-  padding-left: 1rem;
   height: 100%;
   &--separator {
     margin-top: 1rem;


### PR DESCRIPTION
- Set list container padding to 0.5 rem
- Aligned the other styles to match with the above fix