### PR TITLE
ENT - RR2-115  [OXD]UI issues in left menu panel of reports and analytics screen

### DIFF
--- a/components/src/core/components/Divider/_variables.scss
+++ b/components/src/core/components/Divider/_variables.scss
@@ -1,2 +1,2 @@
 $oxd-divider-border: $oxd-border !default;
-$oxd-divider-color: $oxd-interface-gray-lighten-2-color !default;
+$oxd-divider-color: $oxd-interface-gray-lighten-5-color !default;

--- a/components/src/core/components/TableSidebar/table-left-panel.scss
+++ b/components/src/core/components/TableSidebar/table-left-panel.scss
@@ -64,8 +64,13 @@
         &:hover,
         &:focus-within,
         &.active {
-          background-color: rgba(100, 114, 140, 0.1);
+          background-color: $oxd-background-light-gray-color;
           cursor: pointer;
+        }
+        &.active {
+          .oxd-label {
+            font-weight: 700;
+          }
         }
       }
       .oxd-label {

--- a/components/src/core/components/TableSidebar/table-left-panel.scss
+++ b/components/src/core/components/TableSidebar/table-left-panel.scss
@@ -12,6 +12,7 @@
   }
   &--body {
     margin-top: 1rem;
+    padding-bottom: 0.5rem !important;
   }
   &--toggle-btn {
     position: absolute;
@@ -32,7 +33,6 @@
 }
 
 .list {
-  padding-top: 0.5rem !important;
   ul {
     list-style: none;
     margin: 0;

--- a/components/src/core/components/TableSidebar/table-left-panel.scss
+++ b/components/src/core/components/TableSidebar/table-left-panel.scss
@@ -26,7 +26,7 @@
     border: 1px solid $oxd-interface-gray-lighten-2-color;
     &:hover,
     &:focus {
-      color: $oxd-interface-gray-darken-1-color;
+      background-color: $oxd-white-color;
     }
   }
 }

--- a/components/src/styles/_colors.scss
+++ b/components/src/styles/_colors.scss
@@ -16,6 +16,7 @@ $oxd-interface-gray-lighten-1-color: #cfd3de !default;
 $oxd-interface-gray-lighten-2-color: #e8eaef !default;
 $oxd-interface-gray-lighten-3-color: #dee2e6 !default;
 $oxd-interface-gray-lighten-4-color: #efefef !default;
+$oxd-interface-gray-lighten-5-color: #eeeff3 !default;
 
 /* OXD - Background & Overly Colors */
 $oxd-background-gray-color: #b8bdc7 !default;


### PR DESCRIPTION
- Left panel filter tabs on hover background color changed to #f1f2f5
- Left panel filter tabs font-weight of active status changed to 700
- Color of the divider changed to #eeeff3
- Toggle button icon styles changed
- 