### PR TITLE
ENT - RMP-349 "The loading spinner is shown when it's not required to display"

### DIFF
--- a/components/src/core/components/List/List.vue
+++ b/components/src/core/components/List/List.vue
@@ -72,6 +72,7 @@
             :createOptions="quickSearchOptions"
             :modelValue="state.selectedQuickSearch"
             @update:modelValue="quickSearchSelect"
+            @dropdown:clear="quickSearchOnClear"
           >
             <template v-slot:iconSlot>
               <oxd-icon-button
@@ -294,11 +295,13 @@ export default defineComponent({
           label: value.candidateName,
         };
         emit('quick-search:onSelect', value);
-      } else {
-        state.selectedQuickSearch = null;
-        emit('quick-search:onClear');
       }
     };
+
+    const quickSearchOnClear = () => {
+      state.selectedQuickSearch = null;
+      emit('quick-search:onClear')
+    }
 
     const tableSort = value => {
       state.currentSortFields = value;
@@ -379,6 +382,7 @@ export default defineComponent({
       sidePanelListOnHeaderBtnClick,
       sidePanelListOnSelect,
       quickSearchSelect,
+      quickSearchOnClear,
       showFilterDrawer,
       applySearch,
       resetSearch,

--- a/components/src/core/components/List/List.vue
+++ b/components/src/core/components/List/List.vue
@@ -85,7 +85,7 @@
               ></oxd-icon-button>
             </template>
             <template v-slot:option="{data}">
-              <oxd-profile-pic size="small" :imageSrc="data.avatar_url" />
+              <oxd-profile-pic size="extra-small" :imageSrc="data.avatar_url" />
               <span class="margin-left">{{ data.label }}</span>
             </template>
           </oxd-quick-search>

--- a/components/src/core/components/List/list.scss
+++ b/components/src/core/components/List/list.scss
@@ -106,3 +106,12 @@
     }
   }
 }
+
+.oxd-autocomplete-search-wrapper {
+  :deep(.oxd-autocomplete-dropdown) {
+    padding: 0.5rem 0.25rem 0.5rem 0.25rem;
+  }
+  :deep(.oxd-autocomplete-option) {
+    padding: 0.25rem 0.75rem;
+  }
+}

--- a/components/src/core/components/ProfilePic/ProfilePic.vue
+++ b/components/src/core/components/ProfilePic/ProfilePic.vue
@@ -102,4 +102,12 @@ export default defineComponent({
     height: 2.8rem;
   }
 }
+
+.header-image.profile-image--extra-small {
+  .img-tag,
+  :deep(img) {
+    width: 2.4rem;
+    height: 2.4rem;
+  }
+}
 </style>

--- a/components/src/core/components/ProfilePic/types.ts
+++ b/components/src/core/components/ProfilePic/types.ts
@@ -1,9 +1,10 @@
+export const SIZE_EXRTA_SMALL = 'small';
 export const SIZE_SMALL = 'small';
 export const SIZE_MEDIUM = 'medium';
 
-export const SIZES = [SIZE_SMALL, SIZE_MEDIUM];
+export const SIZES = [SIZE_EXRTA_SMALL, SIZE_SMALL, SIZE_MEDIUM];
 
-export type ImageSize = typeof SIZE_SMALL | typeof SIZE_MEDIUM;
+export type ImageSize = typeof SIZE_EXRTA_SMALL | typeof SIZE_SMALL | typeof SIZE_MEDIUM;
 
 export const TARGET_SELF = '_self';
 export const TARGET_BLANK = '_blank';


### PR DESCRIPTION
1. Moved "quick-search:onClear" from "quickSearchSelect" method's null condition checker to a separate method called "quickSearchOnClear"
2. added a new size for profile pic component 'extra-small' and fixed quick search issues mentioned by Mike.