### PR TITLE
ENT: Fix list container min-height

### DIFF
--- a/components/src/core/components/List/List.vue
+++ b/components/src/core/components/List/List.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="oxd-list-container w-100 vh-100 d-flex align-start"
+    class="oxd-list-container w-100 min-vh-100 d-flex align-start"
     :class="{
       'table-left-panel-open':
         config.table.leftPanel.visible && state.isLeftPanelOpen,

--- a/components/src/styles/_utility.scss
+++ b/components/src/styles/_utility.scss
@@ -49,6 +49,10 @@
   width: 100vh;
 }
 
+.min-vh-100 {
+  min-height: 100vh;
+}
+
 .overflow {
   &-hidden {
     overflow: hidden;


### PR DESCRIPTION
- Set min-height instead of height, to allow container to grow when page size is large.