### PR TITLE
ENT - fit width of select inside list to it's content

### DIFF
--- a/components/src/core/components/List/list.scss
+++ b/components/src/core/components/List/list.scss
@@ -62,6 +62,11 @@
       flex-wrap: nowrap;
       .oxd-select-wrapper {
         max-width: 195px;
+        .oxd-select-text {
+          max-width: 195px;
+          width: -moz-fit-content;
+          width: fit-content;
+        }
       }
     }
   }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5012626/157641291-6f2114ea-3cb5-409a-8df6-1b1b62b89446.png)

After:

![image](https://user-images.githubusercontent.com/5012626/157641420-9bb15d31-0020-4797-b2e6-abc8c2f13453.png)
