### PR TITLE
[RMP-392] Add disabled tooltip for buttons

### DIFF
--- a/components/src/core/components/Button/Button.vue
+++ b/components/src/core/components/Button/Button.vue
@@ -3,7 +3,7 @@
     type="button"
     :class="classes"
     :style="style"
-    :tooltip="tooltip"
+    :tooltip="computedTooltip"
     :flow="flow"
   >
     <slot name="icon">
@@ -102,6 +102,10 @@ export default defineComponent({
       type: String,
       default: null,
     },
+    disabledTooltip: {
+      type: String,
+      default: null,
+    },
     flow: {
       type: String,
       default: TOOLTIP_TOP,
@@ -112,6 +116,14 @@ export default defineComponent({
   },
 
   computed: {
+    computedTooltip(): string {
+      if (this.$attrs.disabled) {
+        return this.disabledTooltip;
+      } else {
+        return this.tooltip;
+      }
+    },
+    
     classes(): object {
       return {
         'oxd-button': true,

--- a/storybook/stories/core/components/Button/Button.stories.js
+++ b/storybook/stories/core/components/Button/Button.stories.js
@@ -14,6 +14,7 @@ import {
   TYPE_LABEL_FEEDBACK_DANGER,
   TYPE_TEXT,
   TYPE_TOOL,
+  TOOLTIP_BOTTOM,
 } from '@orangehrm/oxd/core/components/Button/types';
 import {
   ICON_SIZES,
@@ -158,6 +159,14 @@ export const Disabled = Template.bind({});
 Disabled.args = {
   label: 'Button',
   disabled: true,
+};
+
+export const DisabledWithTooltip = Template.bind({});
+DisabledWithTooltip.args = {
+  label: 'Button',
+  disabled: true,
+  disabledTooltip: 'Disabled',
+  flow: TOOLTIP_BOTTOM,
 };
 
 export const ButtonWithIcon = Template.bind({});


### PR DESCRIPTION
Add support to add tooltips for oxd-button when the button is in disabled state only