### PR TITLE
ENT: Show brackets around number of records found in list

### DIFF
--- a/components/src/core/components/List/List.vue
+++ b/components/src/core/components/List/List.vue
@@ -272,7 +272,7 @@ export default defineComponent({
       const itemCount =
         state.selectedItemIndexes.length || props.filteredTotalRecordsCount;
       return `
-        ${itemCount}
+        (${itemCount})
         ${
           itemCount > 1 || itemCount === 0
             ? config.value.table.topBar.listRecordCount.multiTerm


### PR DESCRIPTION
Show brackets around the number of records found. Eg:

(100) Candidates Found

This matches the behavior in goal list.