### PR TITLE
ENT - RMP-348 Quick search trigger on keypress enter

### DIFF
--- a/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
+++ b/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
@@ -89,6 +89,7 @@ export default defineComponent({
     'dropdown:opened',
     'dropdown:closed',
     'dropdown:blur',
+    'select:enter',
   ],
 
   props: {
@@ -251,6 +252,9 @@ export default defineComponent({
       }
       this.dropdownOpen = false;
       this.$emit('dropdown:blur');
+    },
+    onSelectEnter() {
+      this.$emit('select:enter');
     },
   },
 });

--- a/components/src/core/components/Input/Autocomplete/QuickSearchInput.vue
+++ b/components/src/core/components/Input/Autocomplete/QuickSearchInput.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="oxd-autocomplete-search-wrapper">
     <oxd-autocomplete-input
+      ref="autocompleteInput"
       v-bind="$attrs"
       @update:modelValue="onModelUpdate($event)"
       @update:searchTerm="onSearchTerm"
@@ -45,6 +46,7 @@ export default defineComponent({
       this.$emit('update:searchTerm', searchTerm);
     },
     onClear() {
+      this.$refs.autocompleteInput.searchTerm = null;
       this.$emit('dropdown:clear');
     },
     onOpen() {

--- a/components/src/core/components/Input/Autocomplete/QuickSearchInput.vue
+++ b/components/src/core/components/Input/Autocomplete/QuickSearchInput.vue
@@ -9,6 +9,7 @@
       @dropdown:opened="onOpen()"
       @dropdown:closed="onClosed()"
       @dropdown:blur="onBlur()"
+      @select:enter="onSelectEnter"
     >
       <template v-for="(_, slot) of $slots" v-slot:[slot]="scope">
         <slot :name="slot" v-bind="scope" />
@@ -37,6 +38,7 @@ export default defineComponent({
     'dropdown:opened',
     'dropdown:closed',
     'dropdown:blur',
+    'select:enter',
   ],
   methods: {
     onModelUpdate($event: Option) {
@@ -57,6 +59,9 @@ export default defineComponent({
     },
     onBlur() {
       this.$emit('dropdown:blur');
+    },
+    onSelectEnter() {
+      this.$emit('select:enter');
     },
   },
 });

--- a/components/src/core/components/Input/Autocomplete/QuickSearchInput.vue
+++ b/components/src/core/components/Input/Autocomplete/QuickSearchInput.vue
@@ -48,7 +48,6 @@ export default defineComponent({
       this.$emit('update:searchTerm', searchTerm);
     },
     onClear() {
-      this.$refs.autocompleteInput.searchTerm = null;
       this.$emit('dropdown:clear');
     },
     onOpen() {
@@ -58,6 +57,7 @@ export default defineComponent({
       this.$emit('dropdown:closed');
     },
     onBlur() {
+      this.$refs.autocompleteInput.dropdownOpen = false;
       this.$emit('dropdown:blur');
     },
     onSelectEnter() {

--- a/components/src/core/components/List/List.vue
+++ b/components/src/core/components/List/List.vue
@@ -320,7 +320,8 @@ export default defineComponent({
     };
 
     const quickSearchKeywordSearch = () => {
-      quickSearchComponent.value.onClear();
+      state.quickSearchTriggered = true;
+      quickSearchComponent.value.onBlur();
       state.selectedQuickSearch = {
         label: state.quickSearchTerm,
       };

--- a/components/src/core/components/List/List.vue
+++ b/components/src/core/components/List/List.vue
@@ -323,6 +323,15 @@ export default defineComponent({
       emit('quick-search:onSearch', state.quickSearchTerm);
     };
 
+    const setQuickSearchTerm = (value: string) => {
+      state.quickSearchTerm = value
+      emit('quick-search:onSetSearchTerm', value);
+    };
+
+    const quickSearchKeywordSearch = () => {
+      emit('quick-search:onSearch', state.quickSearchTerm);
+    };
+
     const tableSort = value => {
       state.currentSortFields = value;
       emit('update:order', value);

--- a/components/src/core/components/List/List.vue
+++ b/components/src/core/components/List/List.vue
@@ -335,6 +335,15 @@ export default defineComponent({
       emit('quick-search:onSearch', state.quickSearchTerm);
     };
 
+<<<<<<< HEAD
+=======
+    const quickSearchOnClear = () => {
+      state.selectedQuickSearch = null;
+      state.selectedQuickSearch = null;
+      emit('quick-search:onClear');
+    };
+
+>>>>>>> e9cc686... RMP-348
     const tableSort = value => {
       state.currentSortFields = value;
       emit('update:order', value);

--- a/components/src/core/components/List/List.vue
+++ b/components/src/core/components/List/List.vue
@@ -324,7 +324,10 @@ export default defineComponent({
     };
 
     const setQuickSearchTerm = (value: string) => {
-      state.quickSearchTerm = value
+      state.quickSearchTerm = value;
+      state.selectedQuickSearch = {
+        label: value,
+      };
       emit('quick-search:onSetSearchTerm', value);
     };
 

--- a/components/src/core/components/List/List.vue
+++ b/components/src/core/components/List/List.vue
@@ -65,6 +65,7 @@
         </template>
         <template v-slot:toggleOptions>
           <oxd-quick-search
+            ref="quickSearchComponent"
             v-if="config.table.topBar.quickSearch.visible"
             :style="config.table.topBar.quickSearch.style"
             :placeholder="config.table.topBar.quickSearch.placeholder"
@@ -154,7 +155,7 @@ import ProfilePic from '@orangehrm/oxd/core/components/ProfilePic/ProfilePic.vue
 import Pagination from '@orangehrm/oxd/core/components/Pagination/Pagination.vue';
 import images from '../ProfilePic/images';
 
-import {defineComponent, reactive, computed} from 'vue';
+import {defineComponent, reactive, computed, ref} from 'vue';
 
 export default defineComponent({
   components: {
@@ -235,6 +236,8 @@ export default defineComponent({
       currentSortFields: {},
       quickSearchTriggered: false,
     });
+
+    const quickSearchComponent = ref(null);
 
     const config = computed(() => props.configurations);
 
@@ -329,6 +332,7 @@ export default defineComponent({
     };
 
     const quickSearchKeywordSearch = () => {
+      quickSearchComponent.value.onClear()
       state.selectedQuickSearch = {
         label: state.quickSearchTerm,
       };
@@ -338,7 +342,6 @@ export default defineComponent({
 <<<<<<< HEAD
 =======
     const quickSearchOnClear = () => {
-      state.selectedQuickSearch = null;
       state.selectedQuickSearch = null;
       emit('quick-search:onClear');
     };
@@ -441,6 +444,7 @@ export default defineComponent({
       exportBtn,
       eventBinder,
       config,
+      quickSearchComponent,
     };
   },
 });

--- a/components/src/core/components/List/List.vue
+++ b/components/src/core/components/List/List.vue
@@ -325,13 +325,13 @@ export default defineComponent({
 
     const setQuickSearchTerm = (value: string) => {
       state.quickSearchTerm = value;
-      state.selectedQuickSearch = {
-        label: value,
-      };
       emit('quick-search:onSetSearchTerm', value);
     };
 
     const quickSearchKeywordSearch = () => {
+      state.selectedQuickSearch = {
+        label: state.quickSearchTerm,
+      };
       emit('quick-search:onSearch', state.quickSearchTerm);
     };
 

--- a/components/src/core/components/List/List.vue
+++ b/components/src/core/components/List/List.vue
@@ -75,6 +75,7 @@
             @update:modelValue="quickSearchSelect"
             @dropdown:clear="quickSearchOnClear"
             @update:searchTerm="setQuickSearchTerm"
+            @select:enter="quickSearchKeywordSearch"
           >
             <template v-slot:iconSlot>
               <oxd-icon-button
@@ -319,29 +320,11 @@ export default defineComponent({
     };
 
     const quickSearchKeywordSearch = () => {
-      state.quickSearchTriggered = true;
+      quickSearchComponent.value.onClear();
       state.selectedQuickSearch = {
         label: state.quickSearchTerm,
       };
       emit('quick-search:onSearch', state.quickSearchTerm);
-    };
-
-    const setQuickSearchTerm = (value: string) => {
-      state.quickSearchTerm = value;
-      emit('quick-search:onSetSearchTerm', value);
-    };
-
-    const quickSearchKeywordSearch = () => {
-      quickSearchComponent.value.onClear()
-      state.selectedQuickSearch = {
-        label: state.quickSearchTerm,
-      };
-      emit('quick-search:onSearch', state.quickSearchTerm);
-    };
-
-    const quickSearchOnClear = () => {
-      state.selectedQuickSearch = null;
-      emit('quick-search:onClear');
     };
 
     const tableSort = value => {

--- a/components/src/core/components/List/List.vue
+++ b/components/src/core/components/List/List.vue
@@ -339,14 +339,11 @@ export default defineComponent({
       emit('quick-search:onSearch', state.quickSearchTerm);
     };
 
-<<<<<<< HEAD
-=======
     const quickSearchOnClear = () => {
       state.selectedQuickSearch = null;
       emit('quick-search:onClear');
     };
 
->>>>>>> e9cc686... RMP-348
     const tableSort = value => {
       state.currentSortFields = value;
       emit('update:order', value);


### PR DESCRIPTION
1. Added keypress enter event to quick search
2. Triggered dropdown hide when on keypress enter event by accessing child element "dropdownOpen" value through refs.