### PR TITLE
ENT - RMP-343 "Search candidate via search box & Perform filter > Searched character isn't getting removed from the search box "

### DIFF
--- a/components/src/core/components/List/List.vue
+++ b/components/src/core/components/List/List.vue
@@ -65,6 +65,7 @@
         </template>
         <template v-slot:toggleOptions>
           <oxd-quick-search
+            ref="quickSearch"
             v-if="config.table.topBar.quickSearch.visible"
             :style="config.table.topBar.quickSearch.style"
             :placeholder="config.table.topBar.quickSearch.placeholder"
@@ -228,6 +229,7 @@ export default defineComponent({
   setup(props, {emit}) {
     const sampleImages = images;
 
+    const quickSearch = ref(null);
     const state = reactive({
       currentPage: 1,
       isLeftPanelOpen: true,
@@ -435,6 +437,7 @@ export default defineComponent({
       exportBtn,
       eventBinder,
       config,
+      quickSearch,
     };
   },
 });


### PR DESCRIPTION
In this PR I've cleared the values of quick search autocomplete by accessing child component's values through refs

Vue App fix

https://websvn.orangehrm.com/orangehrm?op=comp&compare[]=/enterprise/branch/recruitment-vue-conversion/@170618&compare[]=/enterprise/branch/recruitment-vue-conversion/@170619

https://websvn.orangehrm.com/orangehrm?op=comp&compare[]=/enterprise/branch/recruitment-vue-conversion/@170618&compare[]=/enterprise/branch/recruitment-vue-conversion/@170620