### PR TITLE
ENT - RMP-475 "Quick search candidates MUST reset left filters by stage and the detailed field filters such that the search is applied to ALL candidates"

### DIFF
--- a/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
+++ b/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
@@ -73,7 +73,6 @@ import AutocompleteChips from '@orangehrm/oxd/core/components/Input/Autocomplete
 import sanitizeHtml from 'sanitize-html';
 import dropdownDirectionDirective from '../../../../directives/dropdown-direction';
 
-
 export default defineComponent({
   name: 'oxd-autocomplete-input',
   inheritAttrs: false,
@@ -148,15 +147,17 @@ export default defineComponent({
 
   computed: {
     computedOptions(): Option[] {
-      return this.options.map((option: Option) => {
-        let _selected = false;
-        if (Array.isArray(this.modelValue)) {
-          _selected = this.modelValue.findIndex(o => o.id === option.id) > -1;
-        } else if (this.modelValue?.id === option.id) {
-          _selected = true;
-        }
-        return {...option, _selected};
-      }).filter((option: Option) =>  !option._selected);
+      return this.options
+        .map((option: Option) => {
+          let _selected = false;
+          if (Array.isArray(this.modelValue)) {
+            _selected = this.modelValue.findIndex(o => o.id === option.id) > -1;
+          } else if (this.modelValue?.id === option.id) {
+            _selected = true;
+          }
+          return {...option, _selected};
+        })
+        .filter((option: Option) => !option._selected);
     },
     dropdownClasses(): object {
       return {

--- a/components/src/core/components/Input/DateInput.vue
+++ b/components/src/core/components/Input/DateInput.vue
@@ -22,11 +22,11 @@
     </div>
     <transition name="transition-fade-down">
       <div
-          v-click-outside="closeDropdown"
-          v-if="open"
-          class="oxd-date-input-calendar"
-          @keyup.esc="closeDropdown"
-          v-dropdown-direction
+        v-click-outside="closeDropdown"
+        v-if="open"
+        class="oxd-date-input-calendar"
+        @keyup.esc="closeDropdown"
+        v-dropdown-direction
       >
         <oxd-calendar
           v-bind="$attrs"
@@ -76,7 +76,6 @@ import Input from '@orangehrm/oxd/core/components/Input/Input.vue';
 import Calendar from '@orangehrm/oxd/core/components/Calendar/Calendar.vue';
 import clickOutsideDirective from '../../../directives/click-outside';
 import dropdownDirectionDirective from '../../../directives/dropdown-direction';
-
 
 export default defineComponent({
   name: 'oxd-date-input',

--- a/components/src/core/components/Input/DropdownInput.vue
+++ b/components/src/core/components/Input/DropdownInput.vue
@@ -39,7 +39,12 @@
       />
     </div>
     <transition name="transition-fade-down">
-      <ul role="listbox" v-if="open" class="oxd-dropdown-options" v-dropdown-direction>
+      <ul
+        role="listbox"
+        v-if="open"
+        class="oxd-dropdown-options"
+        v-dropdown-direction
+      >
         <li
           v-for="(option, index) in filteredOptions"
           :ref="`optElm-${index}`"

--- a/components/src/core/components/Input/MultiSelect/MultiSelectInput.vue
+++ b/components/src/core/components/Input/MultiSelect/MultiSelectInput.vue
@@ -62,7 +62,6 @@ import SelectOption from '@orangehrm/oxd/core/components/Input/Select/SelectOpti
 import MultiSelectChips from '@orangehrm/oxd/core/components/Input/MultiSelect/MultiSelectChips.vue';
 import dropdownDirectionDirective from '../../../../directives/dropdown-direction';
 
-
 export default defineComponent({
   name: 'oxd-multiselect-input',
   inheritAttrs: false,

--- a/components/src/core/components/Input/Select/SelectInput.vue
+++ b/components/src/core/components/Input/Select/SelectInput.vue
@@ -18,7 +18,8 @@
       </template>
     </oxd-select-text>
 
-    <oxd-select-dropdown v-dropdown-direction
+    <oxd-select-dropdown
+      v-dropdown-direction
       v-if="dropdownOpen"
       :class="dropdownClasses"
       :loading="loading"
@@ -55,7 +56,6 @@ import SelectDropdown from '@orangehrm/oxd/core/components/Input/Select/SelectDr
 import SelectOption from '@orangehrm/oxd/core/components/Input/Select/SelectOption.vue';
 import translateMixin from '../../../../mixins/translate';
 import dropdownDirectionDirective from '../../../../directives/dropdown-direction';
-
 
 export default defineComponent({
   name: 'oxd-select-input',

--- a/components/src/core/components/Input/Time/TimeInput.vue
+++ b/components/src/core/components/Input/Time/TimeInput.vue
@@ -31,7 +31,6 @@ import TimePicker from '@orangehrm/oxd/core/components/Input/Time/TimePicker.vue
 import {parseDate, formatDate} from '../../../../utils/date';
 import dropdownDirectionDirective from '../../../../directives/dropdown-direction';
 
-
 export default defineComponent({
   name: 'oxd-time-input',
 
@@ -45,7 +44,6 @@ export default defineComponent({
     'click-outside': clickOutsideDirective,
     'dropdown-direction': dropdownDirectionDirective,
   },
-
 
   emits: [
     'update:modelValue',
@@ -80,7 +78,7 @@ export default defineComponent({
       default: 1,
     },
   },
-  
+
   setup(props) {
     const state = reactive({
       open: false,

--- a/components/src/core/components/List/List.vue
+++ b/components/src/core/components/List/List.vue
@@ -17,7 +17,7 @@
       :list-visible="config.table.leftPanel.list.visible"
       :bubble-visible="config.table.leftPanel.list.bubble.visible"
       :button="config.table.leftPanel.header.button"
-      :selected-list-item-id="selectedListItem.id"
+      :selected-list-item-id="selectedListItemId"
       @sidePanelList:onSelect="sidePanelListOnSelect"
       @side-panel:onToggle="toggleSidePanel"
       @sidePanelList:onHeaderBtnClick="sidePanelListOnHeaderBtnClick"
@@ -211,9 +211,8 @@ export default defineComponent({
         currentPage: 1 as number,
       }),
     },
-    selectedListItem: {
-      type: Object,
-      default: () => ({}),
+    selectedListItemId: {
+      type: Number,
     },
     maxPages: {
       type: Number,

--- a/components/src/core/components/Pagination/Pagination.vue
+++ b/components/src/core/components/Pagination/Pagination.vue
@@ -162,11 +162,11 @@ export default defineComponent({
     },
 
     showPagination() {
-      if ((this.totalRecordsCount <= this.pagesList[0]) && (this.length <= 1)) {
+      if (this.totalRecordsCount <= this.pagesList[0] && this.length <= 1) {
         return false;
       }
       return true;
-    }
+    },
   },
 
   methods: {

--- a/components/src/core/components/TableSidebar/TableSidebar.vue
+++ b/components/src/core/components/TableSidebar/TableSidebar.vue
@@ -75,7 +75,7 @@
 </template>
 
 <script lang="ts">
-import {defineComponent, computed, ref, toRef, Ref} from 'vue';
+import {defineComponent, computed, ref} from 'vue';
 import Chip from '@orangehrm/oxd/core/components/Chip/Chip.vue';
 import Button from '@orangehrm/oxd/core/components/Button/Button.vue';
 import IconButton from '@orangehrm/oxd/core/components/Button/Icon.vue';

--- a/components/src/core/components/TableSidebar/TableSidebar.vue
+++ b/components/src/core/components/TableSidebar/TableSidebar.vue
@@ -75,7 +75,7 @@
 </template>
 
 <script lang="ts">
-import {defineComponent, computed, ref} from 'vue';
+import {defineComponent, computed, ref, computed} from 'vue';
 import Chip from '@orangehrm/oxd/core/components/Chip/Chip.vue';
 import Button from '@orangehrm/oxd/core/components/Button/Button.vue';
 import IconButton from '@orangehrm/oxd/core/components/Button/Icon.vue';
@@ -135,18 +135,18 @@ export default defineComponent({
   },
 
   setup(props, {emit}) {
-    const selectedListItem = ref<{
-      id: number;
-      label: string;
-      active: boolean;
-    }>({
-      id: props.selectedListItemId,
-      label: null,
-      active: false,
-    });
+    const selectedListItem = computed({
+      get() {
+        return {
+          id: props.selectedListItemId,
+          label: null,
+          active: false,
+        }
+      },
+      set() {}
+    })
     const isLeftPanelOpen = ref<boolean>(true);
 
-    // TODO: Optimize these duplicated methods; Sandamal
     const buttonData = computed(() => {
       const initialObject = {
         label: 'Button',

--- a/components/src/core/components/TableSidebar/TableSidebar.vue
+++ b/components/src/core/components/TableSidebar/TableSidebar.vue
@@ -37,7 +37,7 @@
           >
             <div
               class="count-container"
-              :class="{active: selectedListItem.id === item.id}"
+              :class="{active: selectedListItemId === item.id}"
             >
               <oxd-chip
                 tabindex="0"
@@ -75,7 +75,7 @@
 </template>
 
 <script lang="ts">
-import {defineComponent, computed, ref} from 'vue';
+import {defineComponent, computed, ref, toRef, Ref} from 'vue';
 import Chip from '@orangehrm/oxd/core/components/Chip/Chip.vue';
 import Button from '@orangehrm/oxd/core/components/Button/Button.vue';
 import IconButton from '@orangehrm/oxd/core/components/Button/Icon.vue';
@@ -135,17 +135,6 @@ export default defineComponent({
   },
 
   setup(props, {emit}) {
-    const selectedListItem = computed({
-      get() {
-        return {
-          id: props.selectedListItemId,
-          label: null,
-          active: false,
-        };
-      },
-      // eslint-disable-next-line
-      set() {},
-    });
     const isLeftPanelOpen = ref<boolean>(true);
 
     const buttonData = computed(() => {
@@ -182,7 +171,6 @@ export default defineComponent({
       label: string;
       active: boolean;
     }) => {
-      selectedListItem.value = item;
       emit('sidePanelList:onSelect', item);
     };
 
@@ -195,7 +183,6 @@ export default defineComponent({
     };
 
     return {
-      selectedListItem,
       customStyles,
       buttonData,
       isLeftPanelOpen,

--- a/components/src/core/components/TableSidebar/TableSidebar.vue
+++ b/components/src/core/components/TableSidebar/TableSidebar.vue
@@ -75,7 +75,7 @@
 </template>
 
 <script lang="ts">
-import {defineComponent, computed, ref, computed} from 'vue';
+import {defineComponent, computed, ref} from 'vue';
 import Chip from '@orangehrm/oxd/core/components/Chip/Chip.vue';
 import Button from '@orangehrm/oxd/core/components/Button/Button.vue';
 import IconButton from '@orangehrm/oxd/core/components/Button/Icon.vue';
@@ -141,10 +141,11 @@ export default defineComponent({
           id: props.selectedListItemId,
           label: null,
           active: false,
-        }
+        };
       },
-      set() {}
-    })
+      // eslint-disable-next-line
+      set() {},
+    });
     const isLeftPanelOpen = ref<boolean>(true);
 
     const buttonData = computed(() => {

--- a/components/src/directives/dropdown-direction/index.ts
+++ b/components/src/directives/dropdown-direction/index.ts
@@ -1,4 +1,4 @@
-import {Directive, DirectiveBinding} from 'vue';
+import {Directive} from 'vue';
 
 function fixPosition(el: HTMLElement) {
   el.classList.remove('--positon-top', '--positon-bottom');


### PR DESCRIPTION
Vue app fixes related to this defect is below,

**Before PR review**
https://websvn.orangehrm.com/orangehrm?op=comp&compare[]=/enterprise/branch/recruitment-vue-conversion/@170737&compare[]=/enterprise/branch/recruitment-vue-conversion/@170738

**After PR review**
https://websvn.orangehrm.com/orangehrm?op=comp&compare[]=/enterprise/branch/recruitment-vue-conversion/symfony/web/vue-app/src/@170783&compare[]=/enterprise/branch/recruitment-vue-conversion/symfony/web/vue-app/src/@170784
https://websvn.orangehrm.com/orangehrm?op=comp&compare[]=/enterprise/branch/recruitment-vue-conversion/symfony/web/vue-app/src/@170784&compare[]=/enterprise/branch/recruitment-vue-conversion/symfony/web/vue-app/src/@170785



Below files shows changes because I ran "yarn lint" locally

components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
components/src/core/components/Input/DateInput.vue
components/src/core/components/Input/DropdownInput.vue
components/src/core/components/Input/MultiSelect/MultiSelectInput.vue
components/src/core/components/Input/Select/SelectInput.vue
components/src/core/components/Input/Time/TimeInput.vue
components/src/core/components/Pagination/Pagination.vue
components/src/directives/dropdown-direction/index.ts