### PR TITLE
ENT - Changes to Focus trap and Focus First element Directives and calendar click outside behaviour 

### DIFF
--- a/components/src/core/components/Calendar/CalendarController.vue
+++ b/components/src/core/components/Calendar/CalendarController.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="oxd-calendar-header">
+  <div class="oxd-calendar-header" v-focus-first-element>
     <oxd-icon
       name="oxd-arrow-left"
       size="extra-small"
@@ -59,6 +59,7 @@ import {defineComponent} from 'vue';
 import Text from '@orangehrm/oxd/core/components/Text/Text.vue';
 import Icon from '@orangehrm/oxd/core/components/Button/Icon.vue';
 import CalendarDropdown from '@orangehrm/oxd/core/components/Calendar/CalendarDropdown.vue';
+import focusFirstElementDirective from '../../../directives/focus-first-element';
 
 export default defineComponent({
   name: 'oxd-calendar-controller',
@@ -81,6 +82,9 @@ export default defineComponent({
     'oxd-text': Text,
     'oxd-icon': Icon,
     'oxd-calendar-dropdown': CalendarDropdown,
+  },
+  directives: {
+    'focus-first-element': focusFirstElementDirective,
   },
   methods: {
     calculateMonth(value: number) {

--- a/components/src/core/components/Input/DateInput.vue
+++ b/components/src/core/components/Input/DateInput.vue
@@ -23,7 +23,7 @@
     </div>
     <transition name="transition-fade-down">
       <div
-        v-click-outside="closeDropdown"
+        v-click-outside="onClickOutside"
         v-if="open"
         class="oxd-date-input-calendar"
         @keyup.esc="closeDropdown"
@@ -35,6 +35,7 @@
           @mousedown.prevent
           v-model="dateSelected"
           :locale="locale"
+          v-focus-trap
         >
           <div class="oxd-date-input-links">
             <div
@@ -77,6 +78,7 @@ import Input from '@orangehrm/oxd/core/components/Input/Input.vue';
 import Calendar from '@orangehrm/oxd/core/components/Calendar/Calendar.vue';
 import clickOutsideDirective from '../../../directives/click-outside';
 import dropdownDirectionDirective from '../../../directives/dropdown-direction';
+import focusTrapDirective from '../../../directives/focus-trap';
 
 export default defineComponent({
   name: 'oxd-date-input',
@@ -91,6 +93,7 @@ export default defineComponent({
   directives: {
     'click-outside': clickOutsideDirective,
     'dropdown-direction': dropdownDirectionDirective,
+    'focus-trap': focusTrapDirective,
   },
 
   props: {
@@ -167,19 +170,23 @@ export default defineComponent({
     closeDropdown($e: KeyboardEvent | null) {
       if ($e && $e.key === 'Escape') $e.stopPropagation();
       this.open = false;
-      this.$refs.oxdIcon.$el?.focus();
+      this.$refs.oxdIcon.focus();
+      this.$emit('dateselect:closed');
+    },
+    onClickOutside() {
+      this.open = false;
       this.$emit('dateselect:closed');
     },
     onClickToday() {
       this.dateSelected = freshDate();
       this.open = false;
-      this.$refs.oxdIcon.$el?.focus();
+      this.$refs.oxdIcon.focus();
     },
     onClickClear() {
       this.dateTyped = '';
       this.dateSelected = null;
       this.open = false;
-      this.$refs.oxdIcon.$el?.focus();
+      this.$refs.oxdIcon.focus();
     },
   },
 

--- a/components/src/directives/focus-first-element/index.ts
+++ b/components/src/directives/focus-first-element/index.ts
@@ -1,0 +1,44 @@
+import {Directive} from 'vue';
+
+export interface FocusFirstHTMLElement extends HTMLElement {
+  activeElement?: Element | null;
+}
+
+const focusableElements = 'input, select, textarea, [tabindex], [href]';
+const excludeElements = 'button:not(.oxd-dialog-close-button,.modal-reset-button)';
+
+const focusOnFirstElement = (element: Element, matchingString: string) => {
+  const firstFocusableElement = element.querySelectorAll(matchingString)[0];
+  if (firstFocusableElement) {
+    (firstFocusableElement as HTMLElement).focus();
+  }
+};
+
+const focusonFirstElementDirective: Directive = {
+  mounted(el: FocusFirstHTMLElement) {
+    el.activeElement = document.activeElement;
+    focusOnFirstElement(el, focusableElements + ', ' + excludeElements);
+  },
+  beforeUnmount(el: FocusFirstHTMLElement, binding) {
+    const {arg} = binding;
+    if (arg === 'return-focus') {
+      if (el.activeElement && (el.activeElement as HTMLElement).offsetParent) {
+        (el.activeElement as HTMLElement).focus();
+      } else {
+        let rightPanel = binding.instance?.$root?.$el.parentNode;
+        if (!rightPanel) {
+          rightPanel = document.body;
+        }
+        if (rightPanel) {
+          focusOnFirstElement(
+            rightPanel,
+            focusableElements + ', ' + excludeElements,
+          );
+        }
+      }
+    } else {
+      return;
+    }
+  },
+};
+export default focusonFirstElementDirective;

--- a/components/src/directives/focus-trap/index.ts
+++ b/components/src/directives/focus-trap/index.ts
@@ -1,0 +1,52 @@
+import {Directive} from 'vue';
+
+export type TabHandler = (e: KeyboardEvent) => void;
+
+export interface FocusTrapHTMLElement extends HTMLElement {
+  activeElement?: Element | null;
+  _tabClicking?: TabHandler;
+}
+
+const focusableElements = 'input, select, textarea, [tabindex], [href]';
+const focusableButtonElements = 'button';
+
+const focusTrapDirective: Directive = {
+  mounted(el: FocusTrapHTMLElement) {
+    const focusableContent = el.querySelectorAll(
+      focusableElements + ', ' + focusableButtonElements,
+    );
+
+    const firstFocusableElement = focusableContent[0];
+    const lastFocusableElement = focusableContent[focusableContent.length - 1];
+
+    el._tabClicking = function(e: KeyboardEvent) {
+      const isTabPressed = e.key === 'Tab' || e.keyCode === 9;
+
+      if (!isTabPressed) {
+        return;
+      }
+
+      if (e.shiftKey) {
+        // if shift key pressed for shift + tab combination
+        if (document.activeElement === firstFocusableElement) {
+          (lastFocusableElement as HTMLElement).focus(); // add focus for the last focusable element
+          e.preventDefault();
+        }
+      } else {
+        // if tab key is pressed
+        if (document.activeElement === lastFocusableElement) {
+          // if focused has reached to last focusable element then focus first focusable element after pressing tab
+          (firstFocusableElement as HTMLElement).focus(); // add focus for the first focusable element
+          e.preventDefault();
+        }
+      }
+    };
+    document.addEventListener('keydown', el._tabClicking);
+  },
+  unmounted(el: FocusTrapHTMLElement) {
+    if (!el._tabClicking) return;
+    document.removeEventListener('keydown', el._tabClicking, true);
+    delete el._tabClicking;
+  },
+};
+export default focusTrapDirective;


### PR DESCRIPTION
Had to create a new function in the Dateinput component to fire when click outside action is happening.
This was setting the focus back to the calendar icon previously.
Clicking outside should remove focus from the component and the calendar icon