### PR TITLE
ENT - RMP-557 - Shows "No results found" instead "Searching "when searching right after getting no results from the previous search 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,1 +1,3 @@
 2022-04-19 - 64859152abe759529d145b96af6bcdf232501517 - AutocompleteInput.vue - Added translation to placeholder, imported translationMixin and updated unit tests [autocomplete-input.spec.ts, quicksearch-input.spec.ts]
+
+2022-04-27 - 142465669cff13509290ca84ea9914cdfad613b8 - AutocompleteInput.vue - cleared options each on every search initiation to refrain from showing old list items untill the API request resolves

--- a/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
+++ b/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
@@ -246,6 +246,7 @@ export default defineComponent({
       }
     },
     doSearch() {
+      this.options = [];
       new Promise((resolve) => {
         if (this.createOptions) {
           resolve(this.createOptions(this.searchTerm));

--- a/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
+++ b/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
@@ -253,21 +253,19 @@ export default defineComponent({
         } else {
           throw new Error('createOptions not defined');
         }
-      })
-        .then((resolved) => {
-          if (resolved && Array.isArray(resolved)) {
-            if (resolved.length > 0) {
-              this.options = resolved.slice(0, 5);
-            } else {
-              this.options = [];
-            }
+      }).then((resolved) => {
+        if (resolved && Array.isArray(resolved)) {
+          if (resolved.length > 0) {
+            this.options = resolved.slice(0, 5);
           } else {
-            throw new Error('options returned are not array');
+            this.options = [];
           }
-        })
-        .finally(() => {
-          this.loading = false;
-        });
+        } else {
+          this.options = [];
+          throw new Error('options returned are not array');
+        }
+        this.loading = false;
+      });
     },
     search() {
       if (this.debouncer) {

--- a/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
+++ b/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
@@ -246,7 +246,6 @@ export default defineComponent({
       }
     },
     doSearch() {
-      this.options = [];
       new Promise((resolve) => {
         if (this.createOptions) {
           resolve(this.createOptions(this.searchTerm));
@@ -254,6 +253,7 @@ export default defineComponent({
           throw new Error('createOptions not defined');
         }
       }).then((resolved) => {
+        this.loading = false;
         if (resolved && Array.isArray(resolved)) {
           if (resolved.length > 0) {
             this.options = resolved.slice(0, 5);
@@ -261,10 +261,8 @@ export default defineComponent({
             this.options = [];
           }
         } else {
-          this.options = [];
           throw new Error('options returned are not array');
         }
-        this.loading = false;
       });
     },
     search() {


### PR DESCRIPTION
**Scenario**
1. Search for a non existing keyword
2. Again search for matching keyword

**Current behaviour**
Gets "No results found" when the search is running

**Expected behaviour**
Should get "Searching" whenever it's searching

**Given solution**
It happens due to setting the value of "loading" to false in promise "finally". Moved this..loading = false only resolving block.
**_After the fix it only shows "No results found" when the searching is done there's no matching to be shown_**