### PR TITLE
ENT - RMP-594

### DIFF
--- a/components/src/core/components/Button/Icon.vue
+++ b/components/src/core/components/Button/Icon.vue
@@ -77,6 +77,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    noFocus: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   emits: ['click'],
@@ -85,6 +89,7 @@ export default defineComponent({
     classes(): object {
       return {
         'oxd-icon-button': true,
+        'no-focus': this.noFocus,
       };
     },
     tooltipText() {

--- a/components/src/core/components/Button/icon.scss
+++ b/components/src/core/components/Button/icon.scss
@@ -17,7 +17,7 @@
   align-items: center;
   flex-direction: column;
 
-  &:focus,
+  &:not(.no-focus):focus,
   &:hover {
     outline: 0;
     background-color: $oxd-icon-button--hover;

--- a/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
+++ b/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
@@ -187,7 +187,7 @@ export default defineComponent({
       );
       const filter = new RegExp(searchValue, 'i');
       return this.computedOptions.map((option: Option) => {
-        return option.label.replace(filter, match => {
+        return option.label.replace(filter, (match) => {
           return sanitizeHtml(`<b>${match}</b>`);
         });
       });
@@ -298,6 +298,15 @@ export default defineComponent({
         }
       }
       this.dropdownOpen = false;
+    },
+  },
+  watch: {
+    modelValue: {
+      handler(val) {
+        if (Array.isArray(this.modelValue) && this.modelValue.length === 0) {
+          this.searchTerm = null;
+        }
+      },
     },
   },
 });

--- a/components/src/core/components/TableSidebar/__tests__/__snapshots__/TableSidebar.spec.ts.snap
+++ b/components/src/core/components/TableSidebar/__tests__/__snapshots__/TableSidebar.spec.ts.snap
@@ -29,7 +29,7 @@ exports[`TableSidebar.vue with oxd-chip on left renders OXD TableSidebar  with c
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" nofocus="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -40,7 +40,7 @@ exports[`TableSidebar.vue with oxd-chip on left renders OXD TableSidebar  with c
   </div>
   <div class="oxd-table-left-panel--body"></div>
   <!--v-if-->
-  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" nofocus="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -75,7 +75,7 @@ exports[`TableSidebar.vue with oxd-chip on left renders OXD TableSidebar with ch
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" nofocus="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -110,7 +110,7 @@ exports[`TableSidebar.vue with oxd-chip on left renders OXD TableSidebar with ch
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" nofocus="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -123,7 +123,7 @@ exports[`TableSidebar.vue with oxd-chip on left renders OXD TableSidebar with ch
   <div class="oxd-table-left-panel--footer list">
     <ul></ul>
   </div>
-  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" nofocus="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -158,7 +158,7 @@ exports[`TableSidebar.vue with oxd-chip on left renders OXD TableSidebar with ch
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" nofocus="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -168,7 +168,7 @@ exports[`TableSidebar.vue with oxd-chip on left renders OXD TableSidebar with se
     <div class="table-header-action-btn-container">
       <div class="table-header-action-btns">
         <oxd-button-stub label="New Report" iconname="oxd-add" displaytype="secondary" size="long" iconsize="medium" iconrightsize="medium" flow="right" class="table-header-action-btn w-75"></oxd-button-stub>
-        <oxd-icon-button-stub size="extra-large" name="oxd-new-folder" withcontainer="true" disabled="false" tooltip="New Folder" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="table-header-action-secondary-btn"></oxd-icon-button-stub>
+        <oxd-icon-button-stub size="extra-large" name="oxd-new-folder" withcontainer="true" disabled="false" tooltip="New Folder" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" nofocus="false" class="table-header-action-secondary-btn"></oxd-icon-button-stub>
       </div>
       <oxd-divider-stub class="oxd-table-left-panel--separator"></oxd-divider-stub>
     </div>
@@ -177,7 +177,7 @@ exports[`TableSidebar.vue with oxd-chip on left renders OXD TableSidebar with se
   <div class="oxd-table-left-panel--footer list">
     <ul></ul>
   </div>
-  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" nofocus="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -210,7 +210,7 @@ exports[`TableSidebar.vue with oxd-icon on left renders OXD TableSidebar  with i
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" nofocus="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -221,7 +221,7 @@ exports[`TableSidebar.vue with oxd-icon on left renders OXD TableSidebar  with i
   </div>
   <div class="oxd-table-left-panel--body"></div>
   <!--v-if-->
-  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" nofocus="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -256,7 +256,7 @@ exports[`TableSidebar.vue with oxd-icon on left renders OXD TableSidebar with ic
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" nofocus="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -291,7 +291,7 @@ exports[`TableSidebar.vue with oxd-icon on left renders OXD TableSidebar with ic
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" nofocus="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -304,7 +304,7 @@ exports[`TableSidebar.vue with oxd-icon on left renders OXD TableSidebar with ic
   <div class="oxd-table-left-panel--footer list">
     <ul></ul>
   </div>
-  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" nofocus="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
 </div>
 `;
 
@@ -339,6 +339,6 @@ exports[`TableSidebar.vue with oxd-icon on left renders OXD TableSidebar with ic
       </li>
     </ul>
   </div>
-  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
+  <oxd-icon-button-stub name="oxd-arrow-left" size="xxx-small" withcontainer="true" disabled="false" flow="top" iconstyles="[object Object]" showtooltipwhendisabled="false" nofocus="false" class="oxd-table-left-panel--toggle-btn"></oxd-icon-button-stub>
 </div>
 `;


### PR DESCRIPTION
In this PR Iv'e fixed the below reopened scenarios,

https://orangehrmenterprise.atlassian.net/browse/RMP-594?focusedCommentId=15545

- Once the user inputs invalid values to multi-selectors fields (Candidates, Job titles, job vacancy), the user can see the “invalid” error message appear. But after clicking the reset button those invalid values are not getting reset and the “invalid” error message getting disappeared. Even after that, the user can click the search button with invalid data. Then candidate list shows irrelevant data according to the search.

- After clicking on the reset icon, still, the icon is in highlighted state. Discussed with mike and it is not the expected behavior.