### PR TITLE
RMP-594 - Fixed; autocomplete is not clearing when clicking on reste …

### DIFF
--- a/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
+++ b/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
@@ -187,7 +187,7 @@ export default defineComponent({
       );
       const filter = new RegExp(searchValue, 'i');
       return this.computedOptions.map((option: Option) => {
-        return option.label.replace(filter, match => {
+        return option.label.replace(filter, (match) => {
           return sanitizeHtml(`<b>${match}</b>`);
         });
       });
@@ -298,6 +298,16 @@ export default defineComponent({
         }
       }
       this.dropdownOpen = false;
+    },
+  },
+
+  watch: {
+    modelValue: {
+      handler() {
+        if (Array.isArray(this.modelValue) && this.modelValue.length === 0) {
+          this.searchTerm = null;
+        }
+      },
     },
   },
 });


### PR DESCRIPTION
[https://orangehrmenterprise.atlassian.net/browse/RMP-594?focusedCommentId=15545](https://orangehrmenterprise.atlassian.net/browse/RMP-594?focusedCommentId=15545)

[FIXED] Autocomplete input doesn't get reset when clicking on reset button when its model value is invalid

solution:
Set null to the "searchTerm" when the modelValue is an empty array