### PR TITLE
ENT - RMP-566 - bug fix

### DIFF
--- a/components/src/core/components/Chip/chip.scss
+++ b/components/src/core/components/Chip/chip.scss
@@ -1,7 +1,7 @@
 @import "../../../styles";
 
 .oxd-chip {
-  border-radius: 3em;
+  border-radius: 1em;
   line-height: 1;
   font-weight: 400;
   font-size: 12px;

--- a/components/src/core/components/Input/Autocomplete/AutocompleteChips.vue
+++ b/components/src/core/components/Input/Autocomplete/AutocompleteChips.vue
@@ -4,7 +4,7 @@
       v-for="(option, index) in selected"
       :key="`${index}-selected-${option.id}`"
       :label="option.label"
-      class="oxd-autocomplete-chips-selected"
+      class="oxd-autocomplete-chips-selected align-end"
     >
       <oxd-icon
         name="x"

--- a/components/src/core/components/Input/Autocomplete/autocomplete-input.scss
+++ b/components/src/core/components/Input/Autocomplete/autocomplete-input.scss
@@ -191,6 +191,8 @@
       background-color: $oxd-dropdown-chip-clear-background-color;
       color: $oxd-dropdown-chip-clear-font-color;
       margin-left: $oxd-dropdown-chip-margin;
+      width: $oxd-file-button-font-size;
+      height: $oxd-file-button-font-size;
     }
     & .--disabled,
     & .--readonly {


### PR DESCRIPTION
In this PR I've changed,
1. the border radius from 3 rem to 1 rem.
It has been only used in DropdownInput.vue, AutocompleteChips.vue, AutocompleteInput.vue, MultiselectChips.vue, MultiselectInput.vue and Tablesidebar.vue
and the fix mentioned in (1) should apply to the above components.

2. Newly added "align-end" to the AutocompleteChips.vue component fixes stretching icon issue as per the issue [RMP-566](https://orangehrmenterprise.atlassian.net/browse/RMP-566) and it will align the content to bottom (waiting for Mike's approval).

3. Added width and height as per its close icon size (bootstrap icon), to stop the squashed UI issue