### PR TITLE
Adding sanitization for autocomplete highlighted options

### DIFF
--- a/components/src/composables/useSanitize.ts
+++ b/components/src/composables/useSanitize.ts
@@ -1,0 +1,11 @@
+export default function useSanitize() {
+  const sanitizeHtml = function(text: string) {
+    const div = document.createElement('div');
+    const textNode = document.createTextNode(text);
+    div.appendChild(textNode);
+    return div.innerHTML;
+  };
+  return {
+    sanitizeHtml: sanitizeHtml,
+  };
+}

--- a/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
+++ b/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
@@ -70,9 +70,9 @@ import AutocompleteTextInput from '@orangehrm/oxd/core/components/Input/Autocomp
 import AutocompleteDropdown from '@orangehrm/oxd/core/components/Input/Autocomplete/AutocompleteDropdown.vue';
 import AutocompleteOption from '@orangehrm/oxd/core/components/Input/Autocomplete/AutocompleteOption.vue';
 import AutocompleteChips from '@orangehrm/oxd/core/components/Input/Autocomplete/AutocompleteChips.vue';
-import sanitizeHtml from 'sanitize-html';
 import dropdownDirectionDirective from '../../../../directives/dropdown-direction';
 import translateMixin from '../../../../mixins/translate';
+import useSanitize from '../../../composables/useSanitize';
 
 export default defineComponent({
   name: 'oxd-autocomplete-input',
@@ -129,7 +129,7 @@ export default defineComponent({
     dropdownPosition: {
       type: String,
       default: BOTTOM,
-      validator: function (value: Position) {
+      validator: function(value: Position) {
         return DROPDOWN_POSITIONS.indexOf(value) !== -1;
       },
     },
@@ -156,8 +156,7 @@ export default defineComponent({
         .map((option: Option) => {
           let _selected = false;
           if (Array.isArray(this.modelValue)) {
-            _selected =
-              this.modelValue.findIndex((o) => o.id === option.id) > -1;
+            _selected = this.modelValue.findIndex(o => o.id === option.id) > -1;
           } else if (this.modelValue?.id === option.id) {
             _selected = true;
           }
@@ -185,11 +184,15 @@ export default defineComponent({
         /[-/\\^$*+?.()|[\]{}]/g,
         '\\$&',
       );
-      const filter = new RegExp(searchValue, 'i');
+      const sanitizeHtml = useSanitize().sanitizeHtml;
+
       return this.computedOptions.map((option: Option) => {
-        return option.label.replace(filter, (match) => {
-          return sanitizeHtml(`<b>${match}</b>`);
-        });
+        var textParts = option.label.split(searchValue);
+        var sanitizedTextParts = [];
+        for (var i = 0; i < textParts.length; i++) {
+          sanitizedTextParts[i] = sanitizeHtml(textParts[i]);
+        }
+        return sanitizedTextParts.join(`<b>${sanitizeHtml(searchValue)}</b>`);
       });
     },
     selectedItem(): string {
@@ -250,13 +253,13 @@ export default defineComponent({
       }
     },
     doSearch() {
-      new Promise((resolve) => {
+      new Promise(resolve => {
         if (this.createOptions) {
           resolve(this.createOptions(this.searchTerm));
         } else {
           throw new Error('createOptions not defined');
         }
-      }).then((resolved) => {
+      }).then(resolved => {
         this.loading = false;
         if (resolved && Array.isArray(resolved)) {
           if (resolved.length > 0) {


### PR DESCRIPTION
This is the fix for RMP-660/RMP-661

With this fix I have checked the places where we have used v-html . In lib size there are 2 places
1 - Icon.Vue - It is ok to use
2 - List.vue - It is the quick search overriding slot. That is also fine since the options are sanitized inside autocomplete

There are some usages inside the Buzz module. I assume they are already thought-out since HTML content is handled there.