### PR TITLE
ENT - RMP - 435 : removing unnecessary  details in selected Option after selecting

### DIFF
--- a/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
+++ b/components/src/core/components/Input/Autocomplete/AutocompleteInput.vue
@@ -252,11 +252,12 @@ export default defineComponent({
       this.pointer = -1;
       this.dropdownOpen = false;
       this.searchTerm = null;
+      const selectedOption = {id: option.id, label: option.label};
       if (this.multiple) {
         const selected = Array.isArray(this.modelValue) ? this.modelValue : [];
-        this.$emit('update:modelValue', [...selected, option]);
+        this.$emit('update:modelValue', [...selected, selectedOption]);
       } else {
-        this.$emit('update:modelValue', option);
+        this.$emit('update:modelValue', selectedOption);
       }
     },
     doSearch() {


### PR DESCRIPTION
It is enough to have the id, label after selecting autocomplete and multiselect for it's functionality thus removing unnecessary details