### PR TITLE
Ent - Standardise Text Input widget

### DIFF
--- a/components/src/composables/types.ts
+++ b/components/src/composables/types.ts
@@ -22,6 +22,8 @@ export interface FormField {
   processing: Ref<boolean>;
   validate: () => Promise<ErrorField>;
   reset: () => void;
+  startWatcher: () => void;
+  setDirty: (value: boolean) => void;
 }
 
 export interface FormAPI {

--- a/components/src/composables/types.ts
+++ b/components/src/composables/types.ts
@@ -10,6 +10,7 @@ export type Rule = (value?: any) => string | boolean;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ModelValue = Ref<any>;
 export type Rules = Ref<Array<Rule>>;
+export type Disabled = Ref<boolean>;
 
 export type ErrorBag = Array<ErrorField>;
 export type Fieldset = Array<FormField>;

--- a/components/src/composables/useField.ts
+++ b/components/src/composables/useField.ts
@@ -7,12 +7,20 @@ import {
 } from 'vue';
 import {nanoid} from 'nanoid';
 import {injectStrict} from '../utils/injectable';
-import {ErrorField, FormAPI, formKey, ModelValue, Rules} from './types';
+import {
+  Disabled,
+  ErrorField,
+  FormAPI,
+  formKey,
+  ModelValue,
+  Rules,
+} from './types';
 
 export default function useField(fieldContext: {
   fieldLabel: string;
   rules: Rules;
   modelValue: ModelValue;
+  isDisabled: Disabled;
   onReset: () => Promise<void>;
 }) {
   const form = injectStrict<FormAPI>(formKey);
@@ -24,6 +32,8 @@ export default function useField(fieldContext: {
   let watchHandler: WatchStopHandle | undefined;
 
   const validate = (modelValue: ModelValue, rules: Rules) => {
+    if (fieldContext.isDisabled.value)
+      return Promise.resolve({cid: cid.value, errors: []});
     processing.value = true;
     const allValidations = Promise.all(
       rules.value.map(func => {

--- a/components/src/composables/useField.ts
+++ b/components/src/composables/useField.ts
@@ -82,6 +82,10 @@ export default function useField(fieldContext: {
     );
   };
 
+  const setDirty = (value: boolean) => {
+    dirty.value = value;
+  };
+
   const reset = () => {
     dirty.value = false;
     touched.value = false;
@@ -98,6 +102,8 @@ export default function useField(fieldContext: {
     processing,
     validate: () => validate(fieldContext.modelValue, fieldContext.rules),
     reset,
+    startWatcher,
+    setDirty,
   });
 
   onBeforeUnmount(() => {
@@ -109,6 +115,8 @@ export default function useField(fieldContext: {
       processing,
       validate: () => validate(fieldContext.modelValue, fieldContext.rules),
       reset,
+      startWatcher,
+      setDirty,
     });
   });
 

--- a/components/src/composables/useFormValidation.ts
+++ b/components/src/composables/useFormValidation.ts
@@ -55,7 +55,15 @@ export default function useFormValidation() {
   };
 
   const validate = () => {
-    return Promise.all(formState.fieldset.map(field => field.validate()))
+    return Promise.all(
+      formState.fieldset.map(field => {
+        if (!field.dirty.value) {
+          field.setDirty(true);
+          field.startWatcher();
+        }
+        return field.validate();
+      }),
+    )
       .then(results => {
         results.map(errorField => {
           addError(errorField);

--- a/components/src/core/components/Form/Form.vue
+++ b/components/src/core/components/Form/Form.vue
@@ -1,5 +1,6 @@
 <template>
   <form
+    :name="name"
     :class="{
       'oxd-form': true,
       '--empty': !$slots.default,
@@ -28,6 +29,7 @@ export default defineComponent({
   },
 
   props: {
+    name: String,
     loading: {
       type: Boolean,
       default: false,

--- a/components/src/core/components/Input/__tests__/input.spec.ts
+++ b/components/src/core/components/Input/__tests__/input.spec.ts
@@ -25,4 +25,12 @@ describe('Input.vue', () => {
     });
     expect(wrapper.html()).toMatchSnapshot();
   });
+
+  it('on input', async () => {
+    const wrapper = mount(Input, {});
+    const input = wrapper.find('input');
+    await input.trigger('input');
+    expect(wrapper.emitted()).toHaveProperty('update:modelValue');
+    expect(wrapper.emitted()).toHaveProperty('input');
+  });
 });

--- a/components/src/core/components/InputField/InputField.vue
+++ b/components/src/core/components/InputField/InputField.vue
@@ -11,6 +11,7 @@
       :is="component"
       v-bind="$attrs"
       :id="id"
+      :disabled="disabled"
       :hasError="hasError"
       :modelValue="modelValue"
       @update:modelValue="onChange"
@@ -79,6 +80,10 @@ export default defineComponent({
     id: {
       type: String,
     },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
     type: {
       type: String,
       default: TYPE_INPUT,
@@ -103,6 +108,8 @@ export default defineComponent({
   setup(props, context) {
     const modelValue = toRef(props, 'modelValue');
     const rules = toRef(props, 'rules');
+    const isDisabled = toRef(props, 'disabled');
+
     const initialValue = modelValue.value;
 
     const onReset = async () => {
@@ -114,6 +121,7 @@ export default defineComponent({
       fieldLabel: props.label ? props.label : '',
       rules,
       modelValue,
+      isDisabled,
       onReset,
     });
 

--- a/components/src/core/components/InputField/InputField.vue
+++ b/components/src/core/components/InputField/InputField.vue
@@ -2,6 +2,7 @@
   <oxd-input-group
     :label="label"
     :labelIcon="labelIcon"
+    :id="id"
     :message="message"
     class="oxd-input-field-bottom-space"
     :classes="classes"
@@ -9,6 +10,7 @@
     <component
       :is="component"
       v-bind="$attrs"
+      :id="id"
       :hasError="hasError"
       :modelValue="modelValue"
       @update:modelValue="onChange"
@@ -73,6 +75,9 @@ export default defineComponent({
     required: {
       type: Boolean,
       default: false,
+    },
+    id: {
+      type: String,
     },
     type: {
       type: String,

--- a/components/src/core/components/InputField/InputGroup.vue
+++ b/components/src/core/components/InputField/InputGroup.vue
@@ -7,7 +7,7 @@
           :name="labelIcon"
           class="oxd-input-group__label-icon"
         />
-        <oxd-label v-if="label" :label="label" :class="labelClasses" />
+        <oxd-label v-if="label" :id="id" :label="label" :class="labelClasses" />
       </div>
     </slot>
     <div :class="wrapperClasses">
@@ -44,6 +44,9 @@ export default defineComponent({
       type: String,
     },
     message: {
+      type: String,
+    },
+    id: {
       type: String,
     },
     classes: {

--- a/components/src/core/components/Label/Label.vue
+++ b/components/src/core/components/Label/Label.vue
@@ -1,5 +1,5 @@
 <template>
-  <label :class="classes" :style="style">
+  <label :class="classes" :for="id" :style="style">
     {{ label }}
   </label>
 </template>
@@ -15,6 +15,9 @@ export default {
     },
     style: {
       type: Object,
+    },
+    id: {
+      type: String,
     },
   },
 

--- a/components/src/core/components/SchemaForm/SchemaForm.vue
+++ b/components/src/core/components/SchemaForm/SchemaForm.vue
@@ -116,34 +116,62 @@ export default defineComponent({
       }
     };
 
+    const getFormElementId = (
+      fieldType: string,
+      fieldName: string,
+      fieldValue: string | unknown,
+      formName: String,
+    ) => {
+      if (fieldType === 'radio') {
+        return (
+          formName.toString().trim() +
+          '_' +
+          fieldName.toString().trim() +
+          '_' +
+          fieldValue.toString().trim()
+        );
+      } else {
+        return formName.toString().trim() + '_' + fieldName.toString().trim();
+      }
+    };
+
     const createFieldNode = (field: FieldSchema) => {
-      return h(
-        GridItem,
-        {
-          style: field.style,
-          class: field.class,
-        },
-        {
-          default: () =>
-            h(extractFieldComponent(field), {
-              id: field.id ?? nanoid(6),
-              key: field.key,
-              label: $t(field.label),
-              ...(field.props ?? {}),
-              ...(field.listeners ?? {}),
-              rules: Array.from(field.validators?.values() ?? []),
-              modelValue: props.model[field.name],
-              'onUpdate:modelValue': value => {
-                context.emit('update:model', {
-                  ...(props.model as Model),
-                  [field.name]: value,
-                });
-              },
-              required: field.validators?.has('required'),
-              ...(field.type !== 'custom' && {type: field.type}),
-            }),
-        },
-      );
+      if (!props.schema?.name) {
+        throw new Error('Form name is must for schema form');
+      } else {
+        return h(
+          GridItem,
+          {
+            style: field.style,
+            class: field.class,
+          },
+          {
+            default: () =>
+              h(extractFieldComponent(field), {
+                id: getFormElementId(
+                  field.type,
+                  field.name,
+                  field.value,
+                  props.schema.name,
+                ),
+                key: field.key,
+                label: $t(field.label),
+                ...(field.props ?? {}),
+                ...(field.listeners ?? {}),
+                rules: Array.from(field.validators?.values() ?? []),
+                modelValue: props.model[field.name],
+                'onUpdate:modelValue': value => {
+                  context.emit('update:model', {
+                    ...(props.model as Model),
+                    [field.name]: value,
+                  });
+                },
+                required: field.validators?.has('required'),
+                ...(field.type !== 'custom' && {type: field.type}),
+              }),
+          },
+        );
+      }
     };
 
     const createActionNode = (field: FieldSchema) => {
@@ -203,6 +231,7 @@ export default defineComponent({
       h(
         Form,
         {
+          name: props.schema?.name,
           style: props.schema?.style,
           class: props.schema?.class,
           loading: isLoading.value,

--- a/components/src/core/components/SchemaForm/SchemaForm.vue
+++ b/components/src/core/components/SchemaForm/SchemaForm.vue
@@ -126,7 +126,7 @@ export default defineComponent({
         {
           default: () =>
             h(extractFieldComponent(field), {
-              id: field.id,
+              id: field.id ?? nanoid(6),
               key: field.key,
               label: $t(field.label),
               ...(field.props ?? {}),

--- a/components/src/core/components/SchemaForm/types.ts
+++ b/components/src/core/components/SchemaForm/types.ts
@@ -83,6 +83,7 @@ type LayoutSchema = CommonSchemaProperties &
 
 type FormSchema = CommonSchemaProperties & {
   layout: Array<LayoutSchema>;
+  name: String;
 };
 
 export {

--- a/storybook/stories/core/components/Input/Input.stories.js
+++ b/storybook/stories/core/components/Input/Input.stories.js
@@ -1,15 +1,71 @@
 import Input from '@orangehrm/oxd/core/components/Input/Input';
+import InputEvents from './InputEvents.story.vue';
 
 export default {
-  title: 'Example/Input',
+  title: 'Form_Widgets/Input',
   component: Input,
   argTypes: {
-    style: {control: {type: 'object'}},
-    hasError: {control: {type: 'boolean'}},
+    modelValue: {
+      control: {type: 'object'},
+      table: {
+        type: {summary: 'Set value to the input'},
+      },
+    },
+    style: {
+      control: {type: 'object'},
+      table: {
+        type: {summary: 'Set custom style to the input'},
+      },
+    },
+    focus: {
+      control: {type: 'function'},
+      table: {
+        type: {summary: 'Native Inherited Event: Emit focus event from input'},
+      },
+    },
+    blur: {
+      control: {type: 'function'},
+      table: {
+        type: {
+          summary: `Native Inherited Event:` + 'Emit blur event from input',
+        },
+      },
+    },
+    keyUp: {
+      control: {type: 'function'},
+      table: {
+        type: {summary: 'Native Inherited Event:" Emit keyUp event from input'},
+      },
+    },
+    click: {
+      control: {type: 'function'},
+      action: 'clicked',
+      table: {
+        type: {summary: 'Native Inherited Event:: Emit click event from input'},
+      },
+    },
+    input: {
+      control: {type: 'function'},
+      table: {
+        type: {summary: 'Emit input event on adding a input'},
+      },
+    },
+    'update:modelValue': {
+      control: {type: 'function'},
+      table: {
+        type: {summary: 'Emit value on adding a input'},
+      },
+    },
+    hasError: {
+      control: {type: 'boolean'},
+      table: {
+        type: {summary: 'Set error state to the input'},
+      },
+    },
   },
 };
 
-const Template = args => ({
+const Template = (args) => ({
   setup() {
     return {args};
   },
@@ -19,17 +75,97 @@ const Template = args => ({
 
 export const Default = Template.bind({});
 Default.args = {
-  value: 'Input',
+  modelValue: 'input',
+};
+
+Default.parameters = {
+  docs: {
+    source: {
+      code: '<oxd-input \n' + '/>',
+    },
+  },
 };
 
 export const Colored = Template.bind({});
 Colored.args = {
-  value: 'Input',
+  modelValue: 'input',
   style: {backgroundColor: 'aliceblue'},
+};
+
+Colored.parameters = {
+  docs: {
+    source: {
+      code: '<oxd-input \n' + ': style={"backgroundColor": "aliceblue"}/>',
+    },
+  },
 };
 
 export const Error = Template.bind({});
 Error.args = {
-  value: 'Input',
+  modelValue: 'input',
   hasError: true,
+};
+
+Error.parameters = {
+  docs: {
+    source: {
+      code: '<oxd-input \n' + ': style={"backgroundColor": "aliceblue"}/>',
+    },
+  },
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  modelValue: 'input',
+  Disabled: true,
+};
+
+Disabled.parameters = {
+  docs: {
+    source: {
+      code: '<oxd-input \n' + ': Disabled=true/>',
+    },
+  },
+};
+
+export const ReadOnly = Template.bind({});
+ReadOnly.args = {
+  modelValue: 'input',
+  readonly: true,
+};
+
+ReadOnly.parameters = {
+  docs: {
+    source: {
+      code: '<oxd-input \n' + ':readonly=true/>',
+    },
+  },
+};
+
+export const Events = () => InputEvents;
+
+Events.parameters = {
+  docs: {
+    source: {
+      code:
+        '  <div> \n' +
+        '<oxd-input \n' +
+        '@input="onInput()"\n' +
+        '@focus="onFocus()"\n' +
+        '@blur="onBlur()"\n' +
+        '@click="onClick()"\n' +
+        '@keyup="onKeyUp()"\n' +
+        '/>\n' +
+        '</div>\n' +
+        '<div style="margin-top: 2rem">\n' +
+        '<span v-if="InputEvent">Input Event Triggered</span>\n' +
+        '<span v-if="FocusEvent">Focus Event Triggered</span>\n' +
+        '<span v-if="BlurEvent">Blur Event Triggered</span>\n' +
+        '<span v-if="ClickEvent">Click Event Triggered</span>\n' +
+        '<span v-if="KeyUpEvent">KeyUp Event Triggered</span>\n' +
+        '</div>\n' +
+        '//\n' +
+        'File -> InputEvents.story.vue',
+    },
+  },
 };

--- a/storybook/stories/core/components/Input/InputEvents.story.vue
+++ b/storybook/stories/core/components/Input/InputEvents.story.vue
@@ -1,0 +1,67 @@
+<template>
+  <div>
+    <oxd-input
+      @input="onInput()"
+      @focus="onFocus()"
+      @blur="onBlur()"
+      @click="onClick()"
+      @keyup="onKeyUp()"
+    />
+  </div>
+  <div style="margin-top: 2rem">
+    <span v-if="InputEvent">Input Event Triggered</span>
+    <span v-if="FocusEvent">Focus Event Triggered</span>
+    <span v-if="BlurEvent">Blur Event Triggered</span>
+    <span v-if="ClickEvent">Click Event Triggered</span>
+    <span v-if="KeyUpEvent">KeyUp Event Triggered</span>
+  </div>
+</template>
+
+<script>
+import Input from '@orangehrm/oxd/core/components/Input/Input';
+
+export default {
+  data() {
+    return {
+      InputEvent: false,
+      FocusEvent: false,
+      BlurEvent: false,
+      ClickEvent: false,
+      KeyUpEvent: false,
+    };
+  },
+
+  components: {
+    'oxd-input': Input,
+  },
+  methods: {
+    clearFields() {
+      this.InputEvent = false;
+      this.FocusEvent = false;
+      this.BlurEvent = false;
+      this.ClickEvent = false;
+      this.KeyUpEvent = false;
+    },
+    onInput() {
+      this.clearFields();
+      this.InputEvent = true;
+    },
+    onFocus() {
+      this.clearFields();
+      this.FocusEvent = true;
+    },
+    onBlur() {
+      this.clearFields();
+      this.BlurEvent = true;
+    },
+    onClick() {
+      this.clearFields();
+      this.ClickEvent = true;
+    },
+    onKeyUp() {
+      this.clearFields();
+      this.KeyUpEvent = true;
+    },
+  },
+};
+</script>

--- a/storybook/stories/core/components/SchemaForm/SchemaForm.stories.js
+++ b/storybook/stories/core/components/SchemaForm/SchemaForm.stories.js
@@ -73,6 +73,94 @@ Default.args = {
   schema: {...sample},
 };
 
+const CrossValidationTemplate = (args) => ({
+  components: {'oxd-schema-form': SchemaForm},
+  setup() {
+    const {schema, model} = useSchemaForm(args.schema);
+    const onSubmit = (...args) => {
+      console.log(args);
+    };
+    return {
+      model,
+      schema,
+      onSubmit,
+    };
+  },
+  components: {'oxd-schema-form': SchemaForm},
+  template: `<oxd-schema-form :schema="schema" v-model:model="model" v-on:submitValid="onSubmit"></oxd-schema-form>`,
+});
+
+const crossValidationSample = {
+  layout: [
+    {
+      type: 'grid',
+      props: {
+        cols: 2,
+      },
+      children: {
+        default: [
+          {
+            name: 'vacancy',
+            label: 'Vacancy',
+            type: 'select',
+            props: {
+              options: [
+                {id: 1, label: 'Vaccancy One'},
+                {id: 2, label: 'Vaccancy Two'},
+              ],
+            },
+            validators: new Map([['required', required]]),
+          },
+          {
+            name: 'firstName',
+            label: 'First Name',
+            type: 'input',
+            // eslint-disable-next-line @typescript-eslint/ban-types
+            hook: (field, modelvalue) => {
+              const model = modelvalue;
+              const defaultValidtors = new Map();
+              if (model.vacancy?.id === 1) {
+                defaultValidtors.set('required', required);
+              }
+              field.validators = defaultValidtors;
+              return {
+                ...field,
+              };
+            },
+          },
+        ],
+      },
+    },
+    {
+      type: 'divider',
+    },
+    {
+      type: 'action',
+      style: {
+        'margin-top': '0.5rem',
+      },
+      children: {
+        default: [
+          {
+            name: 'submit',
+            label: 'Submit',
+            type: 'button',
+            props: {
+              type: 'submit',
+              displayType: 'secondary',
+            },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+export const CrossValidation = CrossValidationTemplate.bind({});
+CrossValidation.args = {
+  schema: {...crossValidationSample},
+};
+
 export const PromiseBased = Template.bind({});
 PromiseBased.args = {
   schema: new Promise((resolve) => {

--- a/storybook/stories/core/components/SchemaForm/SchemaForm.stories.js
+++ b/storybook/stories/core/components/SchemaForm/SchemaForm.stories.js
@@ -26,6 +26,7 @@ const Template = (args) => ({
 });
 
 const sample = {
+  name: 'sampleForm',
   layout: [
     {
       type: 'grid',
@@ -91,6 +92,7 @@ const CrossValidationTemplate = (args) => ({
 });
 
 const crossValidationSample = {
+  name: 'crossValidationForm',
   layout: [
     {
       type: 'grid',
@@ -179,6 +181,7 @@ const getSchemaWithUser = async function (username) {
       .then((response) => response.json())
       .then((user) => {
         const _schema = {
+          name: 'functionBasedForm',
           layout: [
             {
               type: 'custom',
@@ -228,6 +231,7 @@ FunctionBased.args = {
 export const Advance = Template.bind({});
 Advance.args = {
   schema: {
+    name: 'AdvanceForm',
     layout: [
       {
         type: 'grid',


### PR DESCRIPTION
Following missing items for the Text Input widget has been identified. Refer the [analysis](https://docs.google.com/spreadsheets/d/1Wm9TQmfOHVKBeIpZuRNtsmcmq-wYqr-dF8yuaCzUY6I/edit?usp=sharing) and the [standards](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/edit#heading=h.5x0d5h95i329).

- HTML Attributes
  - Style
  - Auto generated ID
- Schema form behaviors
  - Cannot trigger validation upon another field change - Ex: Updating Field A should trigger a validation of Field B
- UI Guidelines
  - Label associate assistive - Adding the 'for' attribute in the label
- Complete the unit tests
- Story book documentation is not done
    - A description
    - Props
    - Events
    - Stories for different behaviors
    - Code samples