### PR TITLE
Support for a hint for input-fields.

### DIFF
--- a/components/src/core/components/InputField/InputField.vue
+++ b/components/src/core/components/InputField/InputField.vue
@@ -20,6 +20,9 @@
         <slot :name="name" v-bind="slotData" />
       </template>
     </component>
+    <oxd-text v-if="hint" class="orangehrm-input-hint" tag="p">
+      {{ $vt(hint) }}
+    </oxd-text>
   </oxd-input-group>
 </template>
 
@@ -39,8 +42,10 @@ import AutocompleteInput from '@orangehrm/oxd/core/components/Input/Autocomplete
 import SelectInput from '@orangehrm/oxd/core/components/Input/Select/SelectInput.vue';
 import MultiSelectInput from '@orangehrm/oxd/core/components/Input/MultiSelect/MultiSelectInput.vue';
 import TimeInput from '@orangehrm/oxd/core/components/Input/Time/TimeInput.vue';
+import Text from "@orangehrm/oxd/core/components/Text/Text.vue";
 import {Types, Components, TYPES, TYPE_INPUT, TYPE_MAP} from './types';
 import useField from '../../../composables/useField';
+import translateMixin from '../../../mixins/translate';
 
 export default defineComponent({
   name: 'oxd-input-field',
@@ -61,8 +66,10 @@ export default defineComponent({
     'oxd-select-input': SelectInput,
     'oxd-multiselect-input': MultiSelectInput,
     'oxd-time-input': TimeInput,
+    'oxd-text': Text,
   },
 
+  mixins: [translateMixin],
   emits: ['update:modelValue'],
 
   props: {
@@ -102,6 +109,10 @@ export default defineComponent({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       type: Array as PropType<any>,
       default: () => [],
+    },
+    hint: {
+      type: String,
+      default: null,
     },
   },
 

--- a/components/src/core/components/InputField/__tests__/__snapshots__/input-field.spec.ts.snap
+++ b/components/src/core/components/InputField/__tests__/__snapshots__/input-field.spec.ts.snap
@@ -6,7 +6,9 @@ exports[`InputField.vue renders OXD InputField 1`] = `
     <!--v-if-->
     <!--v-if-->
   </div>
-  <div class=""><input class="oxd-input oxd-input--active"></div>
+  <div class=""><input class="oxd-input oxd-input--active">
+    <!--v-if-->
+  </div>
   <!--v-if-->
 </div>
 `;
@@ -22,6 +24,7 @@ exports[`InputField.vue renders OXD InputField type \`file\` 1`] = `
       <!--v-if-->
       <div class="oxd-file-input-div">No file chosen</div><i class="oxd-icon oxd-icon--medium bi-upload oxd-file-input-icon"></i>
     </div>
+    <!--v-if-->
   </div>
   <!--v-if-->
 </div>
@@ -38,6 +41,7 @@ exports[`InputField.vue renders OXD InputField type \`file\` with button 1`] = `
       <div class="oxd-file-button">Browse</div>
       <div class="oxd-file-input-div">No file chosen</div><i class="oxd-icon oxd-icon--medium bi-upload oxd-file-input-icon"></i>
     </div>
+    <!--v-if-->
   </div>
   <!--v-if-->
 </div>
@@ -49,7 +53,22 @@ exports[`InputField.vue renders OXD InputField type \`input\` 1`] = `
     <!--v-if-->
     <!--v-if-->
   </div>
-  <div class=""><input class="oxd-input oxd-input--active"></div>
+  <div class=""><input class="oxd-input oxd-input--active">
+    <!--v-if-->
+  </div>
+  <!--v-if-->
+</div>
+`;
+
+exports[`InputField.vue renders OXD InputField type \`input\` with Hint 1`] = `
+<div class="oxd-input-group oxd-input-field-bottom-space">
+  <div class="oxd-input-group__label-wrapper">
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <div class=""><input class="oxd-input oxd-input--active">
+    <p class="oxd-text oxd-text--p orangehrm-input-hint">This field has a hint</p>
+  </div>
   <!--v-if-->
 </div>
 `;
@@ -60,7 +79,9 @@ exports[`InputField.vue renders OXD InputField type \`textarea\` 1`] = `
     <!--v-if-->
     <!--v-if-->
   </div>
-  <div class=""><textarea class="oxd-textarea oxd-textarea--active oxd-textarea--resize-vertical"></textarea></div>
+  <div class=""><textarea class="oxd-textarea oxd-textarea--active oxd-textarea--resize-vertical"></textarea>
+    <!--v-if-->
+  </div>
   <!--v-if-->
 </div>
 `;

--- a/components/src/core/components/InputField/__tests__/input-field.spec.ts
+++ b/components/src/core/components/InputField/__tests__/input-field.spec.ts
@@ -69,4 +69,16 @@ describe('InputField.vue', () => {
     });
     expect(wrapper.html()).toMatchSnapshot();
   });
+
+  it('renders OXD InputField type `input` with Hint', () => {
+    const wrapper = mount(InputField, {
+      props: {type: 'input', hint: 'This field has a hint'},
+      global: {
+        provide: {
+          [formKey as symbol]: mockFormAPI,
+        },
+      },
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
 });

--- a/components/src/core/components/InputField/input-field.scss
+++ b/components/src/core/components/InputField/input-field.scss
@@ -13,3 +13,7 @@
   content: '*';
   color: $oxd-input-field-required-asterisk-color;
 }
+
+.orangehrm-input-hint {
+  font-size: 0.75rem;
+}

--- a/storybook/stories/core/components/InputField/InputField.stories.js
+++ b/storybook/stories/core/components/InputField/InputField.stories.js
@@ -221,4 +221,13 @@ TimeInput.args = {
   type: 'time',
 };
 
+export const WithHint = Template.bind({});
+WithHint.argTypes = argTypes;
+WithHint.args = {
+  label: 'Name as in Passport',
+  type: 'input',
+  hint: 'Only needed if different from the name in your driving license'
+};
+
+
 export const WithValidation = () => InputFieldValidation;


### PR DESCRIPTION
Added support for hints to input-fields.
Note: when this is approved, the hint support has to be removed from FileInput.vue in the product, currently used in AddCandidate modal.