### PR TITLE
ENT - RMP-479 - Increased the toast indicator icon size

### DIFF
--- a/components/src/core/components/Toast/Icon.vue
+++ b/components/src/core/components/Toast/Icon.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="oxd-toast-icon-container">
     <div :class="iconWrapClasses">
-      <oxd-icon :name="iconName" class="oxd-toast-icon" />
+      <oxd-icon :name="iconName" class="oxd-toast-icon d-flex align-center" />
     </div>
   </div>
 </template>

--- a/components/src/core/components/Toast/__tests__/__snapshots__/icon.spec.ts.snap
+++ b/components/src/core/components/Toast/__tests__/__snapshots__/icon.spec.ts.snap
@@ -2,30 +2,30 @@
 
 exports[`Toast > Icon.vue should renders OXD ToastIcon 1`] = `
 <div class="oxd-toast-icon-container">
-  <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--default"><i class="oxd-icon oxd-icon--medium bi-star oxd-toast-icon"></i></div>
+  <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--default"><i class="oxd-icon oxd-icon--medium bi-star oxd-toast-icon d-flex align-center"></i></div>
 </div>
 `;
 
 exports[`Toast > Icon.vue should renders OXD ToastIcon error 1`] = `
 <div class="oxd-toast-icon-container">
-  <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--error"><i class="oxd-icon oxd-icon--medium bi-exclamation-circle oxd-toast-icon"></i></div>
+  <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--error"><i class="oxd-icon oxd-icon--medium bi-exclamation-circle oxd-toast-icon d-flex align-center"></i></div>
 </div>
 `;
 
 exports[`Toast > Icon.vue should renders OXD ToastIcon info 1`] = `
 <div class="oxd-toast-icon-container">
-  <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--info"><i class="oxd-icon oxd-icon--medium bi-info-circle oxd-toast-icon"></i></div>
+  <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--info"><i class="oxd-icon oxd-icon--medium bi-info-circle oxd-toast-icon d-flex align-center"></i></div>
 </div>
 `;
 
 exports[`Toast > Icon.vue should renders OXD ToastIcon success 1`] = `
 <div class="oxd-toast-icon-container">
-  <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--success"><i class="oxd-icon oxd-icon--medium bi-check2 oxd-toast-icon"></i></div>
+  <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--success"><i class="oxd-icon oxd-icon--medium bi-check2 oxd-toast-icon d-flex align-center"></i></div>
 </div>
 `;
 
 exports[`Toast > Icon.vue should renders OXD ToastIcon warn 1`] = `
 <div class="oxd-toast-icon-container">
-  <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--warn"><i class="oxd-icon oxd-icon--medium bi-exclamation-triangle oxd-toast-icon"></i></div>
+  <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--warn"><i class="oxd-icon oxd-icon--medium bi-exclamation-triangle oxd-toast-icon d-flex align-center"></i></div>
 </div>
 `;

--- a/components/src/core/components/Toast/__tests__/__snapshots__/toast.spec.ts.snap
+++ b/components/src/core/components/Toast/__tests__/__snapshots__/toast.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`Toast > Toast.vue should renders OXD Toast 1`] = `
 <div class="oxd-toast oxd-toast--default" aria-live="assertive">
   <div class="oxd-toast-start">
     <div class="oxd-toast-icon-container">
-      <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--default"><i class="oxd-icon oxd-icon--medium bi-star oxd-toast-icon"></i></div>
+      <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--default"><i class="oxd-icon oxd-icon--medium bi-star oxd-toast-icon d-flex align-center"></i></div>
     </div>
     <div class="oxd-toast-content oxd-toast-content--default">
       <p class="oxd-text oxd-text--p oxd-text--toast-title oxd-toast-content-text">Test Toast</p>
@@ -21,7 +21,7 @@ exports[`Toast > Toast.vue should renders OXD Toast error 1`] = `
 <div class="oxd-toast oxd-toast--error" aria-live="assertive">
   <div class="oxd-toast-start">
     <div class="oxd-toast-icon-container">
-      <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--error"><i class="oxd-icon oxd-icon--medium bi-exclamation-circle oxd-toast-icon"></i></div>
+      <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--error"><i class="oxd-icon oxd-icon--medium bi-exclamation-circle oxd-toast-icon d-flex align-center"></i></div>
     </div>
     <div class="oxd-toast-content oxd-toast-content--error">
       <p class="oxd-text oxd-text--p oxd-text--toast-title oxd-toast-content-text">Test Toast</p>
@@ -38,7 +38,7 @@ exports[`Toast > Toast.vue should renders OXD Toast info 1`] = `
 <div class="oxd-toast oxd-toast--info" aria-live="assertive">
   <div class="oxd-toast-start">
     <div class="oxd-toast-icon-container">
-      <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--info"><i class="oxd-icon oxd-icon--medium bi-info-circle oxd-toast-icon"></i></div>
+      <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--info"><i class="oxd-icon oxd-icon--medium bi-info-circle oxd-toast-icon d-flex align-center"></i></div>
     </div>
     <div class="oxd-toast-content oxd-toast-content--info">
       <p class="oxd-text oxd-text--p oxd-text--toast-title oxd-toast-content-text">Test Toast</p>
@@ -55,7 +55,7 @@ exports[`Toast > Toast.vue should renders OXD Toast success 1`] = `
 <div class="oxd-toast oxd-toast--success" aria-live="assertive">
   <div class="oxd-toast-start">
     <div class="oxd-toast-icon-container">
-      <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--success"><i class="oxd-icon oxd-icon--medium bi-check2 oxd-toast-icon"></i></div>
+      <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--success"><i class="oxd-icon oxd-icon--medium bi-check2 oxd-toast-icon d-flex align-center"></i></div>
     </div>
     <div class="oxd-toast-content oxd-toast-content--success">
       <p class="oxd-text oxd-text--p oxd-text--toast-title oxd-toast-content-text">Test Toast</p>
@@ -72,7 +72,7 @@ exports[`Toast > Toast.vue should renders OXD Toast warn 1`] = `
 <div class="oxd-toast oxd-toast--warn" aria-live="assertive">
   <div class="oxd-toast-start">
     <div class="oxd-toast-icon-container">
-      <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--warn"><i class="oxd-icon oxd-icon--medium bi-exclamation-triangle oxd-toast-icon"></i></div>
+      <div class="oxd-toast-icon-wrap oxd-toast-icon-wrap--warn"><i class="oxd-icon oxd-icon--medium bi-exclamation-triangle oxd-toast-icon d-flex align-center"></i></div>
     </div>
     <div class="oxd-toast-content oxd-toast-content--warn">
       <p class="oxd-text oxd-text--p oxd-text--toast-title oxd-toast-content-text">Test Toast</p>

--- a/components/src/core/components/Toast/_variables.scss
+++ b/components/src/core/components/Toast/_variables.scss
@@ -16,7 +16,7 @@ $oxd-toast-bg-color-info: $oxd-feedback-info-color !default;
 
 $oxd-toast-icon-wrap-size: 3.2rem !default;
 $oxd-toast-icon-wrap-padding: 1rem !default;
-$oxd-toast-icon-font-size: 1.5rem !default;
+$oxd-toast-icon-font-size: 1.875rem !default;
 
 $oxd-toast-close-size: 1rem !default;
 $oxd-toast-close-padding: 0.2rem !default;


### PR DESCRIPTION
In this PR I've increased the toast icon size by considering the goal list icon size.
1. In the goal list the icon size is 30px.
2. converted in to rem and the value is 1.875rem
3. applied it to the oxd toast icon

the above fix will apply to the all the toast types and confirmed with Mike