### PR TITLE
ENT - RMP-541 - bug fix

### DIFF
--- a/components/src/core/components/CardTable/Cell/table-select-input.scss
+++ b/components/src/core/components/CardTable/Cell/table-select-input.scss
@@ -19,4 +19,13 @@
     padding: 0 0 0 0.25rem;
     color: $oxd-interface-gray-darken-1-color;
   }
+  :deep(.oxd-select-dropdown) {
+    .oxd-select-dropdown-inner {
+      .oxd-select-option {
+        span {
+          display: block;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
In this PR I've removed the text truncate only for the table select dropdown component by overriding the styles of select input as per below comment in this defect

https://orangehrmenterprise.atlassian.net/browse/RMP-541?focusedCommentId=15594

## Checklist

- [x] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
