### PR TITLE
ENT - RMP-444

### DIFF
--- a/components/src/core/components/Calendar/_variables.scss
+++ b/components/src/core/components/Calendar/_variables.scss
@@ -60,5 +60,6 @@ $oxd-calendar-controller-background-color: #f1f2f5 !default;
 $oxd-calendar-controller-padding: 0.6rem !default;
 $oxd-calendar-controller-icon-size: 8px !default;
 $oxd-calendar-controller-item-background-color: #f6f7f9 !default;
+$oxd-calendar-controller-item-background-color-selected: $oxd-interface-gray-lighten-2-color !default;
 $oxd-calendar-controller-item-padding: 0.5rem !default;
 $oxd-calendar-controller-item-radius: 0.65rem !default;

--- a/components/src/core/components/Calendar/calendar.scss
+++ b/components/src/core/components/Calendar/calendar.scss
@@ -134,9 +134,11 @@
       border-radius: $oxd-calendar-controller-item-radius;
       width: auto;
       &:hover,
-      &:focus-visible,
-      &.--selected {
+      &:focus-visible {
         background-color: $oxd-calendar-controller-item-background-color;
+      }
+      &.--selected {
+        background-color: $oxd-calendar-controller-item-background-color-selected;
       }
       :deep(.oxd-text--p) {
         white-space: nowrap;

--- a/components/src/core/components/CardTable/Table/table-header-sort-dropdown.scss
+++ b/components/src/core/components/CardTable/Table/table-header-sort-dropdown.scss
@@ -41,9 +41,11 @@
       }
       &:hover,
       &:focus,
-      &:focus-visible,
-      &.--selected {
+      &:focus-visible {
         background-color: $oxd-dropdown-item-hover-color;
+      }
+      &.--selected {
+        background-color: $oxd-dropdown-item-selected-color;
       }
       &:not(:first-child) {
         margin-top: 3px;

--- a/components/src/core/components/CardTable/Table/table.scss
+++ b/components/src/core/components/CardTable/Table/table.scss
@@ -32,7 +32,7 @@
     }
     .oxd-table-body {
       grid-gap: 0;
-      .oxd-table-card {
+      .oxd-table-card:not(:first-child) {
         border-top: 1px solid $oxd-interface-gray-lighten-2-color;
         border-radius: 0;
         .oxd-table-row {

--- a/components/src/core/components/Input/Select/select-input-button.scss
+++ b/components/src/core/components/Input/Select/select-input-button.scss
@@ -193,7 +193,7 @@
   }
   &.--selected {
     border-radius: $oxd-dropdown-option-border-radius;
-    background-color: $oxd-dropdown-option-background--focused;
+    background-color: $oxd-dropdown-option-background--selected;
     cursor: unset;
   }
   @for $i from 1 through 20 {

--- a/components/src/core/components/Input/Select/select-input.scss
+++ b/components/src/core/components/Input/Select/select-input.scss
@@ -213,7 +213,7 @@
   }
   &.--selected {
     border-radius: $oxd-dropdown-option-border-radius;
-    background-color: $oxd-dropdown-option-background--focused;
+    background-color: $oxd-dropdown-option-background--selected;
     cursor: unset;
   }
   @for $i from 1 through 20 {

--- a/components/src/core/components/Input/_variables.scss
+++ b/components/src/core/components/Input/_variables.scss
@@ -89,6 +89,7 @@ $oxd-dropdown-option-color--disabled: $oxd-interface-gray-lighten-1-color !defau
 $oxd-dropdown-option-color--selected: $oxd-interface-gray-lighten-1-color !default;
 $oxd-dropdown-option-background: transparent !default;
 $oxd-dropdown-option-background--focused: #f6f7f9 !default;
+$oxd-dropdown-option-background--selected: $oxd-interface-gray-lighten-2-color !default;
 
 $oxd-dropdown-chip-margin: 5px !default;
 $oxd-dropdown-chip-background-color: #f6f7f9 !default;

--- a/components/src/styles/_variables.scss
+++ b/components/src/styles/_variables.scss
@@ -51,6 +51,7 @@ $oxd-dropdown-padding: 4px !default;
 $oxd-dropdown-ul-padding: 0.5rem 0.25rem !default;
 $oxd-dropdown-li-padding: 0.25rem 0.5rem !default;
 $oxd-dropdown-item-hover-color: #f6f7f9 !default;
+$oxd-dropdown-item-selected-color: $oxd-interface-gray-lighten-2-color !default;
 $oxd-dropdown-dropdown-margin: 5px !default;
 
 // z axis index


### PR DESCRIPTION
 This PR fixes,
 
**Not consistent with other places in the system**
3. The thickness of the Table header’s border-bottom is different from other places in the system.

**Dropdown Related - (All vacancies/Stage/Action button options )**
1. Inbetween options in a dropdown, a horizontal line is showing - All vacancies, Stage dropdown & action button options

Of the below reopen scenarios
 https://orangehrmenterprise.atlassian.net/browse/RMP-444?focusedCommentId=16562

## Checklist

- [x] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
