### PR TITLE
Min gap between label and switch

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+2022-06-16 - aff5d11f5a3a65a227df1053a959355d959a4348 - components/Input/SwitchInput.vue - css only change to increase space between switch label and switch to 15px.
+
 2022-06-13 - 146f216bd9e2ae408eced6af09fe5c937185f20f - components/List/list.scss - Fix the position of 'No Data Found' icon in the List component
 
 2022-06-03 - e45f6bee3abf87ffc71b9265746d2d372a53253f - Label.vue - Explicitly set .oxd-label margin to zero, since it's getting overridden by angular application styles.

--- a/components/src/core/components/Input/_variables.scss
+++ b/components/src/core/components/Input/_variables.scss
@@ -41,7 +41,7 @@ $oxd-switch-selector-height: calc(#{$oxd-switch-height} - 2px);
 $oxd-switch-selector-width: calc(#{$oxd-switch-height} - 2px);
 $oxd-switch-selector-radius: calc(#{$oxd-switch-selector-height} / 2);
 $oxd-switch-selector-color: $oxd-white-color !default;
-$oxd-switch-label-margin: 0.5em;
+$oxd-switch-label-margin: 15px;
 $oxd-switch-off-background-color: $oxd-interface-gray-lighten-2-color !default;
 $oxd-switch-on-background-color: $oxd-primary-input-color !default;
 $oxd-switch-on-disabled-background-color: hsl(25, 100%, 56%, 0.5) !default;

--- a/components/src/core/components/Input/switch-input.scss
+++ b/components/src/core/components/Input/switch-input.scss
@@ -103,6 +103,7 @@
 // label left: move switch to right
 .oxd-switch-wrapper label.--full-width {
   width: 100%;
+  column-gap: $oxd-switch-label-margin;
   .oxd-switch-input.--label-left {
     margin-left: auto;
   }


### PR DESCRIPTION
1. Increased the space between the label and the switch to 15px (suggested by Mark. He confirmed it's ok to add in px here)
2. Use the css gap to make sure there's at least 15px between the label and switch when `useFullWidth=true` mode.

## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [ ] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [x] Changelog.md updated on possible breaking (applicable to ent branch)
