### PR TITLE
LMR-166: When changing the resolutions with "No data found" screen in…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+2022-06-17 - 76707a16abb47778eca8b30784ccd82ae851cf47 - components/List/list.scss - Fixing the issue of When changing the resolutions with "No data found" screen in leave type ,it shows a gap between 2 panels
+
 2022-06-16 - aff5d11f5a3a65a227df1053a959355d959a4348 - components/Input/SwitchInput.vue - css only change to increase space between switch label and switch to 15px.
 
 2022-06-13 - 146f216bd9e2ae408eced6af09fe5c937185f20f - components/List/list.scss - Fix the position of 'No Data Found' icon in the List component

--- a/components/src/core/components/List/list.scss
+++ b/components/src/core/components/List/list.scss
@@ -33,6 +33,9 @@
       top: 42px;
     }
   }
+  .oxd-card-table-wrapper {
+    min-height: calc(75vh - 140px);
+  }
   .table-card-list-wrapper {
     width: 100%;
     height: 100%;


### PR DESCRIPTION
… leave type ,it shows a gap between 2 panels

## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [x] Changelog.md updated on possible breaking (applicable to ent branch)
