### PR TITLE
Added a "compact" mode to Alert

### DIFF
--- a/components/src/core/components/Alert/Alert.vue
+++ b/components/src/core/components/Alert/Alert.vue
@@ -6,7 +6,7 @@
         {{ message }}
       </oxd-text>
     </div>
-    <div class="oxd-alert-action">
+    <div :class="actionClasses">
       <slot></slot>
     </div>
   </div>
@@ -45,6 +45,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    compact: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   computed: {
@@ -52,12 +56,20 @@ export default defineComponent({
       return {
         'oxd-alert': true,
         [`oxd-alert--${this.type}`]: true,
+        'oxd-alert--compact': this.compact,
       };
     },
     contentClasses(): object {
       return {
         'oxd-alert-content': true,
         [`oxd-alert-content--${this.type}`]: true,
+        'oxd-alert-content--compact': this.compact,
+      };
+    },
+    actionClasses(): object {
+      return {
+        'oxd-alert-action': true,
+        'oxd-alert-action--compact': this.compact,
       };
     },
     iconName(): string {

--- a/components/src/core/components/Alert/__tests__/alert.spec.ts
+++ b/components/src/core/components/Alert/__tests__/alert.spec.ts
@@ -23,7 +23,10 @@ describe('Alert.vue', () => {
     });
     expect(wrapper.findAll('.oxd-alert.oxd-alert--compact').length).toEqual(1);
     expect(
-      wrapper.findAll('.oxd-alert-content.oxd-alert-content--compact').length,
+      wrapper.findAll('.oxd-alert-content.oxd-alert-content--compact').length
+    ).toEqual(1);
+    expect(
+      wrapper.findAll('.oxd-alert-action.oxd-alert-action--compact').length
     ).toEqual(1);
   });
   it('Non Compact Alert', () => {
@@ -37,7 +40,10 @@ describe('Alert.vue', () => {
     });
     expect(wrapper.findAll('.oxd-alert.oxd-alert--compact').length).toEqual(0);
     expect(
-      wrapper.findAll('.oxd-alert-content.oxd-alert-content--compact').length,
+      wrapper.findAll('.oxd-alert-content.oxd-alert-content--compact').length
+    ).toEqual(0);
+    expect(
+      wrapper.findAll('.oxd-alert-action.oxd-alert-action--compact').length
     ).toEqual(0);
   });
 });

--- a/components/src/core/components/Alert/__tests__/alert.spec.ts
+++ b/components/src/core/components/Alert/__tests__/alert.spec.ts
@@ -12,4 +12,32 @@ describe('Alert.vue', () => {
     });
     expect(wrapper.html()).toMatchSnapshot();
   });
+  it('Compact Alert', () => {
+    const wrapper = shallowMount(Alert, {
+      props: {
+        show: true,
+        type: 'success',
+        message: 'This is an alert',
+        compact: true,
+      },
+    });
+    expect(wrapper.findAll('.oxd-alert.oxd-alert--compact').length).toEqual(1);
+    expect(
+      wrapper.findAll('.oxd-alert-content.oxd-alert-content--compact').length,
+    ).toEqual(1);
+  });
+  it('Non Compact Alert', () => {
+    const wrapper = shallowMount(Alert, {
+      props: {
+        show: true,
+        type: 'success',
+        message: 'This is an alert',
+        compact: false,
+      },
+    });
+    expect(wrapper.findAll('.oxd-alert.oxd-alert--compact').length).toEqual(0);
+    expect(
+      wrapper.findAll('.oxd-alert-content.oxd-alert-content--compact').length,
+    ).toEqual(0);
+  });
 });

--- a/components/src/core/components/Alert/_variables.scss
+++ b/components/src/core/components/Alert/_variables.scss
@@ -5,6 +5,10 @@ $oxd-alert-border-radius: 1.2rem !default;
 $oxd-alert-margin: 1rem 0 !default;
 $oxd-alert-padding: 1rem !default;
 
+$oxd-alert-compact-border-radius: 0.8rem !default;
+$oxd-alert-compact-padding: 0.5rem 1rem 0.5rem 1rem !default;
+$oxd-alert-compact-height: 46px !default;
+
 $oxd-alert-bg-color-default: $oxd-white-color !default;
 $oxd-alert-bg-color-success: rgba($oxd-feedback-success-color, 0.06) !default;
 $oxd-alert-bg-color-warn: rgba($oxd-feedback-warn-color, 0.06) !default;

--- a/components/src/core/components/Alert/alert.scss
+++ b/components/src/core/components/Alert/alert.scss
@@ -2,6 +2,7 @@
 @import 'variables';
 
 .oxd-alert {
+  box-sizing: content-box;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -33,6 +34,11 @@
     background-color: $oxd-alert-bg-color-info;
   }
 
+  &--compact {
+    min-height: $oxd-alert-compact-height;
+    border-radius: $oxd-alert-compact-border-radius;
+  }
+
   &-content {
     display: flex;
     align-items: center;
@@ -47,6 +53,9 @@
       font-size: $oxd-alert-icon-font-size;
       color: inherit;
     }
+    &--compact {
+      padding: $oxd-alert-compact-padding;
+    }
   }
 
   &-action {
@@ -54,6 +63,11 @@
     flex-wrap: wrap;
     justify-content: flex-end;
     padding: $oxd-alert-padding;
+
+    &--compact {
+      padding: $oxd-alert-compact-padding;
+    }
+
     ::v-deep(.oxd-button) {
       font-size: inherit;
       margin: 0.1rem 0.2rem;

--- a/storybook/stories/core/components/Alert/Alert.stories.js
+++ b/storybook/stories/core/components/Alert/Alert.stories.js
@@ -1,17 +1,54 @@
 import Alert from '@orangehrm/oxd/core/components/Alert/Alert';
 import Button from '@orangehrm/oxd/core/components/Button/Button';
-import {TYPES} from '@orangehrm/oxd/core/components/Alert/types';
+import {TYPES, TYPE_WARN, TYPE_SUCCESS} from '@orangehrm/oxd/core/components/Alert/types';
+import icons from 'bootstrap-icons/font/bootstrap-icons.json';
+import oxdIcons from '@orangehrm/oxd/core/components/Icon/icons'
+const bootstrapIconsNames = Object.keys(icons)
+const oxdIconsNames = Object.keys(oxdIcons)
+const iconNames = [...bootstrapIconsNames, ...oxdIconsNames]
+
 import AlertContainer from './AlertContainer';
 
 export default {
   title: 'Information/Alert',
   component: Alert,
   argTypes: {
+    default: {
+      control: {type: 'text'},
+      table: {
+        type: {summary: 'Slot content. Typically used to add buttons'}
+      },
+    },
     type: {
       control: {type: 'select', options: TYPES},
+      table: {
+        type: {summary: 'Select alert type. Decides the color of the alert and the icon (unless a custom icon is given)'},
+      },
+    },
+    message: {
+      control: {type: 'text'},
+      table: {
+        type: {summary: 'Message to show in the alert'}
+      },
+    },
+    icon: {
+      control: {type: 'select', options: iconNames},
+      table: {
+        type: {summary: 'Icon. If not given, icon is selected based on alert type'}
+      },
     },
     show: {
       control: {type: 'boolean'},
+      table: {
+        type: {summary: 'Whether to show the alert or not'},
+      },
+    },
+    compact: {
+      control: {type: 'boolean'},
+      table: {
+        type: {summary: `Compact alert, which is shorter and has a smaller border radius. ` +
+          `Can be used inside a model, and when only the icon and message are there, but no buttons'`},
+      },
     },
   },
 };
@@ -24,17 +61,45 @@ const Template = args => ({
     'oxd-alert': Alert,
     'oxd-button': Button,
   },
-  template: `<oxd-alert v-bind="args">
-  <oxd-button size="medium" displayType="ghost" label="No, Cancel"/>
-  <oxd-button size="medium" displayType="secondary" label="Yes, Delete"/>
-  </oxd-alert>`,
+  template: `<oxd-alert v-bind="args"><template v-if="${'default' in args}" v-slot>${args.default}</template></oxd-alert>`,
 });
 
 export const Default = Template.bind({});
 Default.args = {
   show: true,
-  type: 'success',
+  type: TYPE_SUCCESS,
   message: 'Are you sure you want to continue?',
+  compact: false,
+  default: `<oxd-button size="medium" displayType="ghost" label="No, Cancel"/><oxd-button size="medium" displayType="secondary" label="Yes, Delete"/>`
 };
+
+Default.parameters = {
+  docs: {
+    source: {
+      code: `<oxd-alert :show="true" type="success" message="Are you sure you want to continue?">
+  <oxd-button size="medium" displayType="ghost" label="No, Cancel"/>
+  <oxd-button size="medium" displayType="secondary" label="Yes, Delete"/>
+</oxd-alert>`
+    }
+  }
+}
+
+export const CompactWithoutButtons = Template.bind({});
+CompactWithoutButtons.args = {
+  show: true,
+  type: TYPE_WARN,
+  message: 'Duplicate Leave Request Found!',
+  compact: true,
+  default: ''
+}
+
+CompactWithoutButtons.parameters = {
+  docs: {
+    source: {
+      code: `<oxd-alert :show="true" type="warn" :compact="true" message="Duplicate Leave Request Found!">
+</oxd-alert>`
+    }
+  }
+}
 
 export const Container = () => AlertContainer;


### PR DESCRIPTION
Which reduces the height and border-radius, to match styles given by Mike for an alert in inside a modal form without buttons.

## Checklist

- [x] Test Coverage is 100% for the newly added code
- [x] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
