### PR TITLE
Extract input focus color to separate sass variable 

### DIFF
--- a/components/src/styles/_variables.scss
+++ b/components/src/styles/_variables.scss
@@ -25,6 +25,8 @@ $oxd_breakpoints: (
 );
 
 /* Input Control */
+$oxd-input-border-focus-color: $oxd-interface-gray-color !default;
+$oxd-input-border-focus-box-shadow-color: rgba(darken($oxd-input-border-focus-color, 10%), 0.12) !default;
 $oxd-input-control-font-size: 12px !default;
 $oxd-input-control-font-color: $oxd-interface-gray-darken-1-color !default;
 $oxd-input-control-font-weight: 400 !default;
@@ -35,9 +37,9 @@ $oxd-input-control-horizontal-padding: 0.5rem !default;
 $oxd-input-control-vertical-padding: 0.675rem !default;
 $oxd-input-control-border--active: $oxd-border
   $oxd-interface-gray-lighten-2-color !default;
-$oxd-input-control-border--focus: $oxd-border $oxd-interface-gray-color !default;
+$oxd-input-control-border--focus: $oxd-border $oxd-input-border-focus-color !default;
 $oxd-input-control-border--error: $oxd-border $oxd-feedback-danger-color !default;
-$oxd-input-control-box-shadow--focus: 1px 1px 6px rgba(35, 35, 36, 0.12) !default;
+$oxd-input-control-box-shadow--focus: 1px 1px 6px $oxd-input-border-focus-box-shadow-color !default;
 $oxd-input-control-box-shadow--error: 0 0 5px 0.2rem rgba(223, 9, 16, 0.1) !default;
 $oxd-input-control-width: 100% !default;
 $oxd-form-min-height: 400px;


### PR DESCRIPTION
Extract input focus color to separate sass variable to make it easy to override it when applying a theme.

## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [ ] Code is linted properly
- [ ] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
