### PR TITLE
Remove border from checked radio button

### DIFF
--- a/components/src/core/components/Input/_variables.scss
+++ b/components/src/core/components/Input/_variables.scss
@@ -56,6 +56,10 @@ $oxd-radio-width: 1rem !default;
 $oxd-radio-label-margin: 0.5em !default;
 $oxd-radio-checked-color: $oxd-primary-input-color !default;
 $oxd-radio-checked-disabled-color: #ffd4b6 !default;
+$oxd-radio-active-border: $oxd-border $oxd-interface-gray-lighten-1-color !default;
+$oxd-radio-checked-active-border: $oxd-border $oxd-radio-checked-color !default;
+$oxd-radio-checked-disabled-border: $oxd-border $oxd-radio-checked-disabled-color !default;
+
 
 $oxd-dropdown-text-padding: 0 0.25rem 0 0.5rem !default;
 $oxd-dropdown-animation-time: 300ms !default;

--- a/components/src/core/components/Input/radio-input.scss
+++ b/components/src/core/components/Input/radio-input.scss
@@ -40,12 +40,16 @@
 
       &:checked + .oxd-radio-input {
         box-shadow: inset 0 0 0 0.3rem $oxd-radio-checked-color;
-        border: $oxd-radio-checked-active-border;
+        &:not(.oxd-radio-input--error) {
+          border: $oxd-radio-checked-active-border;
+        }
       }
 
       &:checked:disabled + .oxd-radio-input {
         box-shadow: inset 0 0 0 0.3rem $oxd-radio-checked-disabled-color;
-        border: $oxd-radio-checked-disabled-border;
+        &:not(.oxd-radio-input--error) {
+          border: $oxd-radio-checked-disabled-border;
+        }
       }
     }
   }

--- a/components/src/core/components/Input/radio-input.scss
+++ b/components/src/core/components/Input/radio-input.scss
@@ -40,10 +40,12 @@
 
       &:checked + .oxd-radio-input {
         box-shadow: inset 0 0 0 0.3rem $oxd-radio-checked-color;
+        border: $oxd-radio-checked-active-border;
       }
 
       &:checked:disabled + .oxd-radio-input {
         box-shadow: inset 0 0 0 0.3rem $oxd-radio-checked-disabled-color;
+        border: $oxd-radio-checked-disabled-border;
       }
     }
   }
@@ -65,11 +67,11 @@
   }
 
   &--active {
-    border: $oxd-input-border--active;
+    border: $oxd-radio-active-border;
   }
 
   &--focus {
-    border: $oxd-border $oxd-radio-checked-color;
+    border: $oxd-radio-checked-active-border;
     outline: 0;
   }
 


### PR DESCRIPTION
## Checklist

- Remove the border from checked radio input
- Change the active (unchecked) radio input border color to #cfd3de ($oxd-interface-gray-lighten-1-color)

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
