### PR TITLE
RMP-685 - fixed infobox dropdown appearing when the model value is a string and set disabled to the prevent css overriding issue from angular application

### DIFF
--- a/components/src/core/components/InfoBox/InfoBox.vue
+++ b/components/src/core/components/InfoBox/InfoBox.vue
@@ -5,6 +5,7 @@
       class="oxd-select-fill-container"
       :style="infoBoxContainerStyles"
       :class="classes"
+      :disabled="disabled"
       @focus="onFocus"
       @blur="onBlur"
       @keyup.esc="onCloseDropdown"
@@ -73,7 +74,7 @@
       </div>
     </button>
     <oxd-select-dropdown
-      v-if="dropdownOpen"
+      v-if="dropdownOpen && !isModelValueString"
       :class="dropdownClasses"
       :style="dropdownStyles"
       :loading="loading"

--- a/storybook/stories/core/components/InfoBox/InfoBox.stories.js
+++ b/storybook/stories/core/components/InfoBox/InfoBox.stories.js
@@ -272,7 +272,6 @@ const sample = {
             type: 'infobox',
             props: {
               infoLabel: 'Date of Application',
-              options,
               numOfTitleRows: 1,
             },
             value: '2022-05-03'


### PR DESCRIPTION
## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [x] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
