### PR TITLE
Added translation support for "AM" and "PM" in TimeInput/ TimePicker

### DIFF
--- a/components/src/core/components/Input/Time/TimeInput.vue
+++ b/components/src/core/components/Input/Time/TimeInput.vue
@@ -14,7 +14,7 @@
       />
       <div class="oxd-time-input-am-pm-wrapper">
         <label :class="amPmLabelClasses"
-          >{{ am ? 'AM' : 'PM' }}
+          >{{ am ? $vt('AM') : $vt('PM') }}
           <input
             class="oxd-time-input-am-pm-checkbox"
             type="checkbox"
@@ -59,6 +59,7 @@ import clickOutsideDirective from '@orangehrm/oxd/directives/click-outside';
 import TimePicker from '@orangehrm/oxd/core/components/Input/Time/TimePicker.vue';
 import {parseDate, formatDate} from '@orangehrm/oxd/utils/date';
 import dropdownDirectionDirective from '@orangehrm/oxd/directives/dropdown-direction';
+import translateMixin from '@orangehrm/oxd/mixins/translate';
 
 export default defineComponent({
   name: 'oxd-time-input',
@@ -73,6 +74,8 @@ export default defineComponent({
     'click-outside': clickOutsideDirective,
     'dropdown-direction': dropdownDirectionDirective,
   },
+
+  mixins: [translateMixin],
 
   emits: [
     'update:modelValue',

--- a/components/src/core/components/Input/Time/TimePicker.vue
+++ b/components/src/core/components/Input/Time/TimePicker.vue
@@ -66,7 +66,7 @@
           value="AM"
           @keydown.enter.stop.prevent="togglePeriod"
         />
-        <label for="am">AM</label>
+        <label for="am">{{ $vt('AM') }}</label>
       </div>
       <div class="oxd-time-period-label">
         <input
@@ -76,7 +76,7 @@
           value="PM"
           @keydown.enter.stop.prevent="togglePeriod"
         />
-        <label for="pm">PM</label>
+        <label for="pm">{{ $vt('PM') }}</label>
       </div>
     </div>
   </div>
@@ -90,6 +90,7 @@ import IconButton from '@orangehrm/oxd/core/components/Button/Icon.vue';
 import clickOutsideDirective from '@orangehrm/oxd/directives/click-outside';
 import focusTrapDirective from '@orangehrm/oxd/directives/focus-trap';
 import focusFirstElementDirective from '@orangehrm/oxd/directives/focus-first-element';
+import translateMixin from '@orangehrm/oxd/mixins/translate';
 
 interface State {
   hour: string;
@@ -114,6 +115,8 @@ export default defineComponent({
     'oxd-input': Input,
     'oxd-icon-button': IconButton,
   },
+
+  mixins: [translateMixin],
 
   emits: ['update:modelValue', 'timepicker:closed'],
 


### PR DESCRIPTION
## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [ ] Code is linted properly
- [ ] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
