### PR TITLE
add new oxd-add icon which has inner fill colour. The existing icon …

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-2022-07-11 - 04000460d9ae787faa266819853d160fec0aba93 - components/src/core/components/Icon/icons.ts - add new oxd-add icon which has innder fill colour. The existing icon was hardcoded with white colour
+2022-07-20 - 04000460d9ae787faa266819853d160fec0aba93 - components/Icon/icons.ts - add new oxd-add icon which has innder fill colour. The existing icon was hardcoded with white colour
 
 2022-07-11 - 983922db066fe3298f70e5be1b42e8fdf9aff2cd - components/Input/Time - changes to functionality and style of Time Input and Picker
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+2022-07-11 - 04000460d9ae787faa266819853d160fec0aba93 - components/src/core/components/Icon/icons.ts - add new oxd-add icon which has innder fill colour. The existing icon was hardcoded with white colour
+
 2022-07-11 - 983922db066fe3298f70e5be1b42e8fdf9aff2cd - components/Input/Time - changes to functionality and style of Time Input and Picker
 
 2022-07-08 - 2d7295d529ac95349ebe163cfb8ffe2aef6ba128 - components/src/core/components/CardTable/Table/table.scss - Change the header padding and in components/src/core/components/List/list.scss - Fix the card padding is not equal in left and right sides issue

--- a/components/src/core/components/Icon/icons.ts
+++ b/components/src/core/components/Icon/icons.ts
@@ -285,6 +285,12 @@ export const oxdAdd: icon = {
     '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 459.3 459.3" style="enable-background:new 0 0 459.3 459.3;" xml:space="preserve"> <style type="text/css"> .st0{fill:#FFFFFF;} </style> <g> <path class="st0" d="M459.3,229.7c0,22.2-18,40.2-40.2,40.2H269.9v149.3c0,22.2-18,40.2-40.2,40.2c-11.1,0-21.1-4.5-28.4-11.8 c-7.3-7.3-11.8-17.3-11.8-28.4l0-149.3H40.2c-11.1,0-21.1-4.5-28.4-11.8C4.5,250.8,0,240.8,0,229.7c0-22.2,18-40.2,40.2-40.2h149.3 V40.2c0-22.2,18-40.2,40.2-40.2c22.2,0,40.2,18,40.2,40.2v149.3h149.3C441.3,189.5,459.3,207.5,459.3,229.7z"/> </g> </svg>',
 };
 
+export const oxdAdd2: icon = {
+  name: 'oxd-add-2',
+  value:
+    '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 459.325 459.325" style="enable-background:new 0 0 459.325 459.325;" xml:space="preserve" ><defs><style>.cls-1{fill:currentColor;}</style></defs><g><path style="fill:currentColor" d="M459.319,229.668c0,22.201-17.992,40.193-40.205,40.193H269.85v149.271c0,22.207-17.998,40.199-40.196,40.193 c-11.101,0-21.149-4.492-28.416-11.763c-7.276-7.281-11.774-17.324-11.769-28.419l-0.006-149.288H40.181 c-11.094,0-21.134-4.492-28.416-11.774c-7.264-7.264-11.759-17.312-11.759-28.413C0,207.471,17.992,189.475,40.202,189.475h149.267 V40.202C189.469,17.998,207.471,0,229.671,0c22.192,0.006,40.178,17.986,40.19,40.187v149.288h149.282 C441.339,189.487,459.308,207.471,459.319,229.668z"/></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g><g></g></svg>',
+};
+
 export const oxdInfo: icon = {
   name: 'oxd-add',
   value: `<?xml version="1.0" encoding="iso-8859-1"?>
@@ -507,6 +513,7 @@ const icons: Icons = {
   'oxd-report-catalogue': oxdReportCatalogue,
   'oxd-hr-administration': oxdHRAdministration,
   'oxd-add': oxdAdd,
+  'oxd-add-2': oxdAdd2,
   'oxd-info': oxdInfo,
   'oxd-location': oxdLocation,
   'oxd-standard-reports': oxdStandardReports,


### PR DESCRIPTION
…was hardcoded with white colour

## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [ ] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [x] Changelog.md updated on possible breaking (applicable to ent branch)
