### PR TITLE
show tool tips in multi line if the content is too lengthy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+2022-07-25 - 23d88c64daee0475d64f9f1f8d2a3b8184ff7864 - styles/_utility.scss - Show tool tips in multi line if the content is too lengthy
+
+
 2022-07-20 - b7038ebe7ef9a2ab5c513ad2c7f1a00f6d31c8af - components/Table/ClassicTable - Fixing column widths in oxd-classic-table
 
 2022-07-11 - 983922db066fe3298f70e5be1b42e8fdf9aff2cd - components/Input/Time - changes to functionality and style of Time Input and Picker

--- a/components/src/styles/_utility.scss
+++ b/components/src/styles/_utility.scss
@@ -122,9 +122,10 @@
       Let the content set the size of the tooltips 
       but this will also keep them from being obnoxious
       */
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  width: fit-content;
+  max-width: 300px;
   padding: 0.25rem 0.5rem;
   border-radius: 0.5rem;
   box-shadow: 0px 25px 25px 0 rgba(0, 0, 0, 0.18);


### PR DESCRIPTION
Issue:
![Screenshot from 2022-07-25 11-47-50](https://user-images.githubusercontent.com/15209297/180736310-0caa1d6f-89d4-4f28-b47d-92e276caae6f.png)

Fix:
![Screenshot from 2022-07-25 14-10-30](https://user-images.githubusercontent.com/15209297/180736385-86b546f9-720d-474b-b114-624c0aa0ce44.png)





## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [ ] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [x] Changelog.md updated on possible breaking (applicable to ent branch)
