### PR TITLE
ENT - RMP-845 - bug fixes

### DIFF
--- a/components/src/core/components/Comments/Comments.vue
+++ b/components/src/core/components/Comments/Comments.vue
@@ -5,6 +5,7 @@
     </div>
     <div
       class="oxd-comment-groups-container"
+      v-if="hasCommentsInside || !(hideEmptyPlaceholder || hasCommentsInside)"
       :class="commentGroupsContainerClasses"
       :style="commentGroupsContainerStyles"
     >
@@ -230,12 +231,16 @@ export default defineComponent({
     });
 
     const commentGroupsContainerStyles = computed(() => {
+      const height =
+        !props.hideEmptyPlaceholder &&
+        hasCommentsInside.value &&
+        props.scrollHeight
+          ? props.scrollHeight
+          : undefined;
       return {
-        'min-height': `${props.commentThreadMinHeight}`,
-        height:
-          hasCommentsInside.value && props.scrollHeight
-            ? props.scrollHeight
-            : undefined,
+        'min-height':
+          !props.hideEmptyPlaceholder && `${props.commentThreadMinHeight}`,
+        height,
       };
     });
 

--- a/components/src/core/components/Comments/comments.scss
+++ b/components/src/core/components/Comments/comments.scss
@@ -44,7 +44,7 @@
 }
 
 .oxd-comment-no-notes-found-container {
-  margin: 1rem 0;
+  padding: 1rem 0;
   .oxd-comment-no-notes-found {
     width: 10rem;
     height: 10rem;


### PR DESCRIPTION
[https://orangehrmenterprise.atlassian.net/browse/RMP-845](https://orangehrmenterprise.atlassian.net/browse/RMP-845)

1. Comments component shouldn't display grey background when "hideEmptyPlaceholder" is true and no comments.
2. Removed an additional space appearing inside the comments container when there are no comments.
3. fixed a sudden movement happening when clearing all the comments and adding a comment when there are no comments. 

## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [x] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
