### PR TITLE
fix disabled styling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+2022-08-23 - 07ef5e0fd2b7f084b9a113d9b74efa0bf8dc0d20 - Button/Icon.vue, Icon/Icon.vue - Icon color for disabled Button/Icon.vue changed to match oxd guide
+
 2022-08-18 - e872d101314dadb0db5c410bf8a44dc5a1366c7c - Calendar/CalendarDropdown.vue - Affects DateInput.vue behavior. Prevent whole page scrolling up when month/year dropdown opened.
 
 2022-08-18 - f7d3683bc3cb8a6cef404c65a1d2cf4530a1d41e - Input/FileInput.vue - added edit file option

--- a/components/src/core/components/Icon/icon.scss
+++ b/components/src/core/components/Icon/icon.scss
@@ -5,7 +5,7 @@
 
 .oxd-icon {
   color: $oxd-icon-font-color;
-  &--disabled {
+  &--disabled, &.--disabled {
     color: $oxd-icon-font-color--disabled;
   }
   &--extra-small {


### PR DESCRIPTION
Fixed issue with disabled styling of the icon button.
Button/Icon.vue is setting the class --disabled on oxd-icon
`    <oxd-icon
      :style="iconStyles"
      :size="size"
      :class="{'--disabled': disabled}"
      :name="name"
    />`

but Icon/Icon.vue expects class `oxd-icon--disabled` for disabled styling.
Updated it to style for both classes `oxd-icon--disabled`  and `--disabled`

Expected Style: https://oxd-prod-infinity.orangehrm.com/pages/button.html

![image](https://user-images.githubusercontent.com/5012626/186085005-b08f3aa4-c61b-4929-a0cd-8f0aa5f30391.png)

## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
