### PR TITLE
Changed to allow clearing time value, removed allowEmpty prop.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+2022-08-24 - 65ddb076d1e499787dd8d4dc7a96237ea06e7ca1 - Input/Time/TimeInput.vue - Now supports clearing value by default. allEmpty prop removed. Time field hint changed to HH:MM (was HH-MM)
+
 2022-08-23 - 07ef5e0fd2b7f084b9a113d9b74efa0bf8dc0d20 - Button/Icon.vue, Icon/Icon.vue - Icon color for disabled Button/Icon.vue changed to match oxd guide
 
 2022-08-18 - e872d101314dadb0db5c410bf8a44dc5a1366c7c - Calendar/CalendarDropdown.vue - Affects DateInput.vue behavior. Prevent whole page scrolling up when month/year dropdown opened.

--- a/components/src/core/components/Input/Time/TimeInput.vue
+++ b/components/src/core/components/Input/Time/TimeInput.vue
@@ -104,25 +104,27 @@ export default defineComponent({
     },
     placeholder: {
       type: String,
-      default: 'HH-MM',
+      default: 'HH:MM',
     },
     step: {
       type: Number,
       default: 1,
-    },
-    allowEmpty: {
-      type: Boolean,
-      default: false,
     },
   },
 
   setup(props, context) {
     const timePickerOpen = ref<boolean>(false);
     const amPmLabelFocus = ref<boolean>(false);
-    let inputTime = props.modelValue || '0';
+    let inputTime = '';
 
-    const state = reactive({
-      time: props.allowEmpty ? null : '01:00',
+    interface TimeInputState {
+      time: string;
+      am: boolean;
+      pickerInput: string | null;
+    }
+
+    const state = reactive<TimeInputState>({
+      time: '',
       am: true,
       pickerInput: props.modelValue,
     });
@@ -160,11 +162,7 @@ export default defineComponent({
     };
 
     const onBlur = (e: Event) => {
-      if (props.allowEmpty) {
-        state.time = inputTime && inputTime !== '0' ? inputTime : null;
-      } else if (inputTime) {
-        state.time = inputTime;
-      }
+      state.time = inputTime;
       e.stopImmediatePropagation();
       context.emit('blur');
     };
@@ -182,6 +180,7 @@ export default defineComponent({
             const formattedTime = formatDate(time, 'hh:mm');
             if (formattedTime) {
               state.time = formattedTime;
+              inputTime = formattedTime;
               state.am = time.getHours() < 12;
             }
           }
@@ -196,18 +195,20 @@ export default defineComponent({
       () => [state.time, state.am],
       () => {
         const validTime = /^(0?[1-9]|1[0-2]):[0-5][0-9]$/.test(state.time);
-        let newModelValue: string | null =
-          state.time + ' ' + (state.am ? 'AM' : 'PM');
-        if (validTime && newModelValue) {
-          const parsedTime = parseDate(newModelValue, 'hh:mm a');
+        let newModelValue: string | null = state.time;
+
+        if (validTime) {
+          const parsedTime = parseDate(
+            state.time + ' ' + (state.am ? 'AM' : 'PM'),
+            'hh:mm a',
+          );
           if (parsedTime) {
             newModelValue = formatDate(parsedTime, 'HH:mm');
-          }
-        }
-        if (newModelValue !== props.modelValue) {
-          if (newModelValue) {
             state.pickerInput = newModelValue;
           }
+        }
+
+        if (newModelValue !== props.modelValue) {
           context.emit('update:modelValue', newModelValue);
         }
       },

--- a/components/src/core/components/Input/Time/TimeInput.vue
+++ b/components/src/core/components/Input/Time/TimeInput.vue
@@ -195,17 +195,17 @@ export default defineComponent({
       () => [state.time, state.am],
       () => {
         const validTime = /^(0?[1-9]|1[0-2]):[0-5][0-9]$/.test(state.time);
-        let newModelValue: string | null = state.time;
+        let newModelValue: string | null =
+          state.time + ' ' + (state.am ? 'AM' : 'PM');
 
         if (validTime) {
-          const parsedTime = parseDate(
-            state.time + ' ' + (state.am ? 'AM' : 'PM'),
-            'hh:mm a',
-          );
+          const parsedTime = parseDate(newModelValue, 'hh:mm a');
           if (parsedTime) {
             newModelValue = formatDate(parsedTime, 'HH:mm');
             state.pickerInput = newModelValue;
           }
+        } else if (state.time === '') {
+          newModelValue = '';
         }
 
         if (newModelValue !== props.modelValue) {

--- a/components/src/core/components/Input/__tests__/__snapshots__/time-input.spec.ts.snap
+++ b/components/src/core/components/Input/__tests__/__snapshots__/time-input.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`TimeInput.vue renders OXD Time Input 1`] = `
   <div class="oxd-time-input">
     <div class="input-outer-wrapper">
       <!--v-if-->
-      <!--v-if--><input class="oxd-input oxd-input--active" placeholder="HH-MM" tabindex="0" maxlength="5">
+      <!--v-if--><input class="oxd-input oxd-input--active" placeholder="HH:MM" tabindex="0" maxlength="5">
     </div>
     <div class="oxd-time-input-am-pm-wrapper"><label class="oxd-time-input-am-pm-label">AM <input class="oxd-time-input-am-pm-checkbox" type="checkbox"></label></div>
     <div class="oxd-time-input-icon-wrapper" tabindex="0"><i class="oxd-icon oxd-icon--medium bi-clock justify-center oxd-time-input-icon oxd-time-input--clock"></i></div>

--- a/components/src/core/components/Input/__tests__/time-input.spec.ts
+++ b/components/src/core/components/Input/__tests__/time-input.spec.ts
@@ -36,7 +36,7 @@ describe('TimeInput.vue', () => {
     });
     await wrapper.find('.oxd-time-input input').setValue('124:16');
     await wrapper.find('.oxd-time-input input').trigger('blur');
-    expect(wrapper.emitted('update:modelValue')).toEqual([['124:16']]);
+    expect(wrapper.emitted('update:modelValue')).toEqual([['124:16 PM']]);
   });
 
   it('passing invalid modelValue sets input to blank AM', async () => {

--- a/components/src/core/components/Input/__tests__/time-input.spec.ts
+++ b/components/src/core/components/Input/__tests__/time-input.spec.ts
@@ -36,10 +36,10 @@ describe('TimeInput.vue', () => {
     });
     await wrapper.find('.oxd-time-input input').setValue('124:16');
     await wrapper.find('.oxd-time-input input').trigger('blur');
-    expect(wrapper.emitted('update:modelValue')).toEqual([['124:16 PM']]);
+    expect(wrapper.emitted('update:modelValue')).toEqual([['124:16']]);
   });
 
-  it('passing invalid modelValue sets input to 01:00 AM', async () => {
+  it('passing invalid modelValue sets input to blank AM', async () => {
     const wrapper = mount(TimeInput, {
       props: {
         modelValue: '26:00',
@@ -48,7 +48,7 @@ describe('TimeInput.vue', () => {
 
     expect(
       (wrapper.find('.oxd-time-input input').element as HTMLInputElement).value,
-    ).toEqual('01:00');
+    ).toEqual('');
     expect(
       wrapper.find('.oxd-time-input-am-pm-wrapper > label').text(),
     ).toEqual('AM');

--- a/storybook/stories/core/components/Input/Time.stories.js
+++ b/storybook/stories/core/components/Input/Time.stories.js
@@ -22,7 +22,8 @@ export default {
 
 const Template = (args) => ({
   setup() {
-    const selected = ref('05:00');
+    const initialValue = args.initialValue ?? '05:00';
+    const selected = ref(initialValue);
     return {args, selected};
   },
   render() {
@@ -40,16 +41,23 @@ const Template = (args) => ({
 });
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  initialValue: '05:00',
+};
+
+export const InitialValuePM = Template.bind({});
+InitialValuePM.args = {
+  initialValue: '17:00',
+};
 
 export const Disabled = Template.bind({});
 Disabled.args = {
   disabled: true,
 };
 
-export const allowEmpty = Template.bind({});
-allowEmpty.args = {
-  allowEmpty: true,
+export const EmptyInitialValue = Template.bind({});
+EmptyInitialValue.args = {
+  initialValue: '',
 };
 
 export const Error = Template.bind({});


### PR DESCRIPTION
Earlier changes support allowEmpty prop made the time input change to 24 hour.
see: https://orangehrmenterprise.atlassian.net/browse/LMR-363

Changed TimeInput default behavior to allow clearing input value, removing conditional logic related to allowEmpty.
Changed default hint to HH:MM (was HH-MM).

## Checklist

- [x] Test Coverage is 100% for the newly added code
- [x] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
