### PR TITLE
Fix blur behavior of DateInput

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+2022-08-26 - e03f4d96f4eb79b922e0c59d6399137a0aa46d41 - Input/DateInput.vue - Fixed issue where date picked from calendar is lost when input is blurred.
+
 2022-08-24 - 65ddb076d1e499787dd8d4dc7a96237ea06e7ca1 - Input/Time/TimeInput.vue - Now supports clearing value by default. allEmpty prop removed. Time field hint changed to HH:MM (was HH-MM)
 
 2022-08-23 - 07ef5e0fd2b7f084b9a113d9b74efa0bf8dc0d20 - Button/Icon.vue, Icon/Icon.vue - Icon color for disabled Button/Icon.vue changed to match oxd guide

--- a/components/src/core/components/Input/DateInput.vue
+++ b/components/src/core/components/Input/DateInput.vue
@@ -206,7 +206,7 @@ export default defineComponent({
     },
   },
 
-  data() {
+  data(): {open: boolean; dateTyped: string | null} {
     return {
       open: false,
       dateTyped: null,
@@ -230,13 +230,19 @@ export default defineComponent({
     onDateTyped(value: string) {
       this.dateTyped = value;
     },
-    onDateSelected() {
+    onDateSelected(value: Date) {
       const oxdDatePicker = this.$refs.oxdInput;
       this.$nextTick(() => {
         const oxdDateInputTriggerBtn = this.$refs.oxdIcon;
         oxdDateInputTriggerBtn.blur();
         const inputElement = oxdDatePicker.$el.querySelectorAll('input');
         inputElement[0]?.focus();
+        const formattedDate = formatDate(value, this.format, {
+          locale: this.locale,
+        });
+        if (formattedDate) {
+          this.dateTyped = formattedDate;
+        }
       });
       this.closeDropdown();
     },

--- a/components/src/core/components/Input/DateInput.vue
+++ b/components/src/core/components/Input/DateInput.vue
@@ -206,7 +206,7 @@ export default defineComponent({
     },
   },
 
-  data(): {open: boolean; dateTyped: string | null} {
+  data() {
     return {
       open: false,
       dateTyped: null,
@@ -230,19 +230,14 @@ export default defineComponent({
     onDateTyped(value: string) {
       this.dateTyped = value;
     },
-    onDateSelected(value: Date) {
+    onDateSelected() {
+      this.dateTyped = null;
       const oxdDatePicker = this.$refs.oxdInput;
       this.$nextTick(() => {
         const oxdDateInputTriggerBtn = this.$refs.oxdIcon;
         oxdDateInputTriggerBtn.blur();
         const inputElement = oxdDatePicker.$el.querySelectorAll('input');
         inputElement[0]?.focus();
-        const formattedDate = formatDate(value, this.format, {
-          locale: this.locale,
-        });
-        if (formattedDate) {
-          this.dateTyped = formattedDate;
-        }
       });
       this.closeDropdown();
     },


### PR DESCRIPTION
Issue:

1) Type a date into Date Input
2) Open Date Picker, and select a different date. (date picker will close, and focus move to Date Input.
3) Click outside Date input.
4) Date Input will revert to originally typed value in step 1) and date selected in date picker will be lost.

https://user-images.githubusercontent.com/5012626/186898556-3601075d-982e-4b56-92d9-8b14c9e0395b.mp4


Fix:
When Date picker is closed, set `this.dateInput = null`. This code is there in main branch as well.


## Checklist

- [x] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [x] Changelog.md updated on possible breaking (applicable to ent branch)
