### PR TITLE
Skip disabled items in keyboard navigation - select, multiselect, autocomplete

### DIFF
--- a/components/src/core/components/Input/Select/navigation-mixin.ts
+++ b/components/src/core/components/Input/Select/navigation-mixin.ts
@@ -22,19 +22,25 @@ export const navigationMixin = defineComponent({
   methods: {
     onSelectDown() {
       if (this.dropdownOpen) {
-        if (this.computedOptions.length - 1 > this.pointer) {
+        const originalPointer = this.pointer;
+        do {
           this.pointer++;
-        } else {
-          this.pointer = this.computedOptions.length - 1;
+        } while (this.pointer < this.computedOptions.length && this.computedOptions[this.pointer]._disabled);
+
+        if (this.pointer >= this.computedOptions.length) {
+          this.pointer = originalPointer;
         }
       }
     },
     onSelectUp() {
       if (this.dropdownOpen) {
-        if (this.pointer > 0) {
+        const originalPointer = this.pointer;
+        do {
           this.pointer--;
-        } else {
-          this.pointer = 0;
+        } while (this.pointer > 0 && this.computedOptions[this.pointer]._disabled)
+
+        if (this.pointer < 0) {
+          this.pointer = originalPointer;
         }
       }
     },


### PR DESCRIPTION
Fix for scenario 6) in RR2-388.

- Keyboard navigation was allowing user to select disabled options from the list.
- Fix was to skip disabled options

## Checklist

- [x] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [ ] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [x] Changelog.md updated on possible breaking (applicable to ent branch)
