### PR TITLE
LAN-42 - defined an option set initial scroll.

### DIFF
--- a/components/src/core/components/Comments/Comments.vue
+++ b/components/src/core/components/Comments/Comments.vue
@@ -243,6 +243,10 @@ export default defineComponent({
       type: String as PropType<GroupBy>,
       default: GROUP_BY_TYPE_GROUP,
     },
+    scrollOnLoad: {
+      type: Boolean,
+      default: true,
+    },
   },
   setup(props, {emit}) {
     const commentGroupsList = ref(null);
@@ -328,8 +332,9 @@ export default defineComponent({
     };
 
     onMounted(() => {
+      debugger;
       comment.value = '';
-      doScroll();
+      if (props.scrollOnLoad) doScroll();
     });
 
     const commentEditHasError = (hasError: boolean) => {

--- a/components/src/core/components/Comments/Comments.vue
+++ b/components/src/core/components/Comments/Comments.vue
@@ -332,7 +332,6 @@ export default defineComponent({
     };
 
     onMounted(() => {
-      debugger;
       comment.value = '';
       if (props.scrollOnLoad) doScroll();
     });

--- a/storybook/stories/core/components/Comments/Comments.stories.js
+++ b/storybook/stories/core/components/Comments/Comments.stories.js
@@ -75,6 +75,16 @@ export default {
         },
       },
     },
+    scrollOnLoad: {
+      control: {type: 'boolean'},
+      defaultValue: true,
+      table: {
+        type: {
+          summary:
+            'Set boolean value to change initial scrolling enable or disable. The default value is true',
+        },
+      },
+    },
     commentBoxLabel: {
       control: {type: 'text'},
       defaultValue: 'Add Comment',


### PR DESCRIPTION
defined an option set initial scroll. by default it's true and scroll automatically unless set it to false

## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [x] Storybook stories are added/updated for the changed areas
- [x] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
