### PR TITLE
ENT - LAN-70 - Specified CSS selector more

### DIFF
--- a/components/src/core/components/Comments/comments.scss
+++ b/components/src/core/components/Comments/comments.scss
@@ -29,7 +29,7 @@
     list-style: none;
     margin-bottom: 0;
     .oxd-comment-group {
-      :deep(.oxd-label) {
+      > :deep(.oxd-label) {
         margin-bottom: $oxd-comment-content-container-margin;
       }
       &:not(:last-child) {


### PR DESCRIPTION
Specified CSS selector to apply margin bottom only for the section title of the comment group

## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [x] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
