### PR TITLE
fixed close icon alignment issue in autocomplete for 3 main resolutions

### DIFF
--- a/components/src/core/components/Input/Autocomplete/autocomplete-input.scss
+++ b/components/src/core/components/Input/Autocomplete/autocomplete-input.scss
@@ -217,6 +217,13 @@
     &:focus-within {
       border: $oxd-input-border--focus;
     }
+    :deep(.oxd-icon-button ) {
+      [class^='bi-']::before,
+      [class*=' bi-']::before {
+        line-height: inherit;
+        display: flex;
+      }
+    }
   }
   &:empty {
     display: none;


### PR DESCRIPTION
## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [ ] Code is linted properly
- [ ] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
