### PR TITLE
OHRM5X-1913: OXD buzz post input not showing line breaks in firefox fix

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxd-components",
-  "version": "1.0.8-alpha.1",
+  "version": "1.0.8",
   "license": "GPL-3.0",
   "scripts": {
     "test:unit": "vue-cli-service test:unit",

--- a/components/src/core/components/Buzz/BuzzPostInput.vue
+++ b/components/src/core/components/Buzz/BuzzPostInput.vue
@@ -125,9 +125,14 @@ export default defineComponent({
       // scrollHeight is not calculated properly with
       // explicit heights. first set element height to auto
       // then calculate scrollheight and set element height
+      textArea.value.removeAttribute('style');
       textArea.value.style.height = 'auto';
+
       if (!textArea.value.value) {
         textArea.value.style.height = '30px';
+        textArea.value.style.overflow = 'hidden';
+        textArea.value.style.whiteSpace = 'nowrap';
+        textArea.value.style.textOverflow = 'ellipsis';
       } else if (textArea.value.scrollHeight < 400) {
         textArea.value.style.height = textArea.value.scrollHeight + 'px';
         textArea.value.style.overflowY = 'hidden';

--- a/components/src/core/components/Buzz/buzz-post-input.scss
+++ b/components/src/core/components/Buzz/buzz-post-input.scss
@@ -31,6 +31,7 @@
     width: 98%;
     resize: none;
     text-align: justify;
+    white-space: pre-wrap;
     word-break: break-word;
     box-sizing: border-box;
     padding: $oxd-buzz-post-input-margin;

--- a/components/src/core/components/Tab/tab-container.scss
+++ b/components/src/core/components/Tab/tab-container.scss
@@ -19,6 +19,7 @@
 @import 'variables';
 
 .oxd-tab {
+  touch-action: pan-y !important;
   &-bar {
     padding: $oxd-tab-bar-padding;
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oxd",
   "license": "GPL-3.0",
-  "version": "1.0.8-alpha.1",
+  "version": "1.0.8",
   "private": true,
   "workspaces": [
     "components",


### PR DESCRIPTION
## Checklist

- [x] Test Coverage is 100% for the newly added code
- [x] Storybook stories are added/updated for the changed areas
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [x] Package version updated
