### PR TITLE
LAN-220 - fixed tinyMce backspace not updating issue

### DIFF
--- a/components/src/core/components/TinyMce/__tests__/tinymce.spec.ts
+++ b/components/src/core/components/TinyMce/__tests__/tinymce.spec.ts
@@ -44,6 +44,6 @@ describe('TinyMce > TinyMce.vue', () => {
     });
     await wrapper.vm.$nextTick();
     await wrapper.setValue('');
-    expect(wrapper.vm.vModel).toEqual('');
+    expect(wrapper.vm.editorValue).toEqual('');
   });
 });


### PR DESCRIPTION
1. Fixed content is not getting updated when on backspace.
2. Fixed content is not getting updated when the content is an empty string
3. Added proper types to the file object

## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [ ] Code is linted properly
- [ ] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
