### PR TITLE
LAN-389 - Removed browser default paragraph styles by overriding

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,6 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install npm dependencies
         run: yarn install
       - name: Lint

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -8,6 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install npm dependencies
         run: yarn install
       - name: Build Storybook

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install npm dependencies
         run: yarn install
       - name: Unit tests

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+2023-02-21 - da64adf3488958ba0837d53dc45c3a6ab38c2bc5 - TinyMce/Skins/lightgray/content.module.css - Removed browser default paragraph styles by overriding
+
 2023-01-26 - 3e627e7fbd8a8a40c929a1df6256893dbc17bcb8 - Input/Autocomplet/AutocompleteInput.vue - handled search term resetting issue in autcompleteinput when on keypress enter
 
 2022-12-30 - 2b89327bcf23d6106fdedeec0f4e6528eee3a1a9 - Icon/icons.ts - Add 6 new icons (oxd-goals, oxd-okrs, oxd-individual, oxd-organizational-structure, oxd-dashboard-performance, oxd-goals-development)

--- a/components/src/core/components/TinyMce/skins/lightgray/content.module.css
+++ b/components/src/core/components/TinyMce/skins/lightgray/content.module.css
@@ -16,6 +16,10 @@ th {
   font-family: Verdana, Arial, Helvetica, sans-serif;
   font-size: 14px;
 }
+p {
+  margin: 0;
+  padding: 0;
+}
 .word-wrap {
   word-wrap: break-word;
   -ms-word-break: break-all;


### PR DESCRIPTION
## Checklist

- [x] Test Coverage is 100% for the newly added code
- [x] Storybook stories are added/updated for the changed areas
- [x] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
