### PR TITLE
ENG-234

### DIFF
--- a/components/src/core/components/TableSidebar/table-left-panel.scss
+++ b/components/src/core/components/TableSidebar/table-left-panel.scss
@@ -137,21 +137,20 @@
     }
   }
 }
+
 .table-header-action-btn {
   margin: 0.5rem 0;
 
   &.no-label {
     min-width: initial;
-    ::v-deep(.oxd-button-label-wrapper) {
+    :deep(.oxd-button-label-wrapper) {
+      /* Safari shows extra 2x15px width for the parent button with `-webkit-box`. */
       visibility: hidden;
-      display: -webkit-box;
-      -webkit-line-clamp: 1;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
       width: 0;
     }
   }
 }
+
 .table-header-action-secondary-btn {
   display: inline-flex;
   background-color: #f0fae4;


### PR DESCRIPTION
Safari fix: Left side panel collapsing (closing)

* Safari shows extra 2x15px width for the parent button with `-webkit-box`.
* `-webkit-line-clamp`, `-webkit-box-orient` are effective only with `-webkit-box`. 
 ** `-webkit-line-clamp: 1;`
 ** `-webkit-box-orient: vertical;`

Othere fixes:
* `overflow: hidden;` not required
* `::v-deep(...)` is deprecated, changed to `:deep(...)`

## Checklist

- [x] Test Coverage is 100% for the newly added code
- [x] Storybook stories are added/updated for the changed areas
- [x] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
