### PR TITLE
LAN-221 - introduced a prop to stack comment delete confirmation message and the actions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+2023-05-09 - c9fa0fab8d949c4e03218f97b9b9e79f99e2c068 - Comments/Comment.vue - Added a prop to stack comment delete confirmation message and the actions
+
 2023-02-22 - 38a57d11c250022d6116fbcb1f71e78125abe5b3 - List/List.vue - Added prop support for No data found message and icon
 
 2023-01-26 - 3e627e7fbd8a8a40c929a1df6256893dbc17bcb8 - Input/Autocomplet/AutocompleteInput.vue - handled search term resetting issue in autcompleteinput when on keypress enter

--- a/components/src/core/components/Comments/Comment.vue
+++ b/components/src/core/components/Comments/Comment.vue
@@ -28,7 +28,6 @@
               <oxd-label
                 :label="comment.user.commenterName"
                 class="oxd-comment-content-author-name"
-                :class="labelClasses"
               />
               <span
                 v-if="comment.labelHint"
@@ -155,6 +154,7 @@
         justify-between
         oxd-mt-5 oxd-p-5
       "
+      :class="{stacked: stackedMessages}"
     >
       <div class="comment-inline-delete-content-wrapper d-flex align-center">
         <oxd-text type="subtitle-2">
@@ -196,7 +196,7 @@
 </template>
 
 <script lang="ts">
-import {defineComponent, ref, computed, nextTick, watch} from 'vue';
+import {defineComponent, ref, computed, nextTick, watch, PropType} from 'vue';
 import translateMixin from '../../../mixins/translate';
 import Chip from '@orangehrm/oxd/core/components/Chip/Chip.vue';
 import Label from '@orangehrm/oxd/core/components/Label/Label.vue';
@@ -265,6 +265,10 @@ export default defineComponent({
     },
     showGroupNamePill: {
       type: Boolean,
+      default: false,
+    },
+    stackedMessages: {
+      type: Boolean as PropType<boolean>,
       default: false,
     },
   },

--- a/components/src/core/components/Comments/Comment.vue
+++ b/components/src/core/components/Comments/Comment.vue
@@ -2,97 +2,49 @@
   <div class="oxd-comment-wrapper">
     <div class="d-flex align-start">
       <div v-if="enableAvatar" class="oxd-comment-avatar-wrapper">
-        <oxd-profile-pic
-          size="medium"
-          :imageSrc="comment.user && comment.user.avatarUrl"
-        />
+        <oxd-profile-pic size="medium" :imageSrc="comment.user && comment.user.avatarUrl" />
       </div>
       <div ref="commentContentWrapper" class="oxd-comment-content-wrapper">
-        <div
-          class="oxd-comment-content-container"
-          :class="{'editable-mode': editable}"
-        >
-          <div
-            class="
+        <div class="oxd-comment-content-container" :class="{ 'editable-mode': editable }">
+          <div class="
               oxd-comment-content-header-container
               d-flex
               justify-between
-            "
-          >
-            <div
-              class="
+            ">
+            <div class="
                 oxd-comment-content-header-label-container
                 d-flex
-              "
-            >
-              <oxd-label
-                :label="comment.user.commenterName"
-                class="oxd-comment-content-author-name"
-              />
-              <span
-                v-if="comment.labelHint"
-                class="oxd-comment-content-header-label-hint"
-                >{{ $vt(comment.labelHint) }}</span
-              >
+              ">
+              <oxd-label :label="comment.user.commenterName" class="oxd-comment-content-author-name" />
+              <span v-if="comment.labelHint" class="oxd-comment-content-header-label-hint">{{ $vt(comment.labelHint)
+              }}</span>
             </div>
-            <div
-              class="
+            <div class="
                 oxd-comment-content-header-actions-container
                 show-on-hover-grid
-              "
-            >
-              <oxd-icon-button
-                v-if="!editable && allowToDelete"
-                data-test="deleteIcon"
-                :name="'oxd-trash'"
-                :size="'extra-small'"
-                :tooltip="$vt('Delete')"
-                :class="'oxd-comment-content-header-action'"
-                :withContainer="false"
-                @click="enableDeleteMode(true)"
-              />
-              <oxd-icon-button
-                v-if="!editable && allowToEdit"
-                data-test="editIcon"
-                :name="'oxd-edit'"
-                :size="'extra-small'"
-                :class="'oxd-comment-content-header-action'"
-                :withContainer="false"
-                :tooltip="$vt('Edit')"
-                @click="enableEditMode"
-              />
+              ">
+              <oxd-icon-button v-if="!editable && allowToDelete" data-test="deleteIcon" :name="'oxd-trash'"
+                :size="'extra-small'" :tooltip="$vt('Delete')" :class="'oxd-comment-content-header-action'"
+                :withContainer="false" @click="enableDeleteMode(true)" />
+              <oxd-icon-button v-if="!editable && allowToEdit" data-test="editIcon" :name="'oxd-edit'"
+                :size="'extra-small'" :class="'oxd-comment-content-header-action'" :withContainer="false"
+                :tooltip="$vt('Edit')" @click="enableEditMode" />
             </div>
           </div>
           <div v-if="editable" class="oxd-comment-content-edit-wrapper">
-            <oxd-comment-box
-              :actionButtonIcon="'oxd-check'"
-              :actionButtonTooltip="$vt('Update')"
-              :modelValue="commentContent"
-              :hasError="commentInlineValidationMsg"
-              :preventAddOnKeyPressEnter="true"
-              @blurCommentBox="blurCommentBox"
-              @update:modelValue="onInputComment"
-              @addComment="onUpdateComment"
-              @keyup.esc.stop="enableEditMode(false)"
-            />
-            <oxd-text
-              v-if="commentInlineValidationMsg"
-              class="oxd-input-field-error-message oxd-input-group__message"
-              tag="span"
-            >
+            <oxd-comment-box :actionButtonIcon="'oxd-check'" :actionButtonTooltip="$vt('Update')"
+              :modelValue="commentContent" :hasError="commentInlineValidationMsg" :preventAddOnKeyPressEnter="true"
+              @blurCommentBox="blurCommentBox" @update:modelValue="onInputComment" @addComment="onUpdateComment"
+              @keyup.esc.stop="enableEditMode(false)" />
+            <oxd-text v-if="commentInlineValidationMsg" class="oxd-input-field-error-message oxd-input-group__message"
+              tag="span">
               {{ commentInlineValidationMsg }}
             </oxd-text>
-            <div
-              class="oxd-comment-content-footer-container d-flex align-center"
-            >
+            <div class="oxd-comment-content-footer-container d-flex align-center">
               <div class="oxd-comment-content-footer-action-container">
                 {{ $vt('Press Esc to') }}
-                <span
-                  v-if="allowToEdit"
-                  class="oxd-comment-content-footer-action --cancel active"
-                  @click="cancelEditMode"
-                  >{{ $vt('Cancel') }}</span
-                >
+                <span v-if="allowToEdit" class="oxd-comment-content-footer-action --cancel active"
+                  @click="cancelEditMode">{{ $vt('Cancel') }}</span>
               </div>
             </div>
           </div>
@@ -105,27 +57,15 @@
             <span v-if="comment.formattedTime">
               {{ $vt('Date') }}: {{ comment.formattedTime }}
             </span>
-            <oxd-chip
-              v-if="
-                showGroupNamePill &&
-                  comment.groupName &&
-                  !comment.customGroupName
-              "
-              :label="$vt(comment.groupName)"
-              class="oxd-comment-group-name-chip"
-              :background-color="'#929baa'"
-              :color="'#fafafc'"
-            />
-            <oxd-chip
-              v-if="
-                showGroupNamePill &&
-                  comment.groupName &&
-                  comment.customGroupName
-              "
-              class="oxd-comment-group-name-chip"
-              :background-color="'#929baa'"
-              :color="'#fafafc'"
-            >
+            <oxd-chip v-if="showGroupNamePill &&
+              comment.groupName &&
+              !comment.customGroupName
+              " :label="$vt(comment.groupName)" class="oxd-comment-group-name-chip" :background-color="'#929baa'"
+              :color="'#fafafc'" />
+            <oxd-chip v-if="showGroupNamePill &&
+              comment.groupName &&
+              comment.customGroupName
+              " class="oxd-comment-group-name-chip" :background-color="'#929baa'" :color="'#fafafc'">
               <span class="oxd-comment-group-name-primary">{{
                 $vt(comment.customGroupName.labelPrimary)
               }}</span>
@@ -133,70 +73,45 @@
                 $vt(comment.customGroupName.labelSecondary)
               }}</span>
             </oxd-chip>
-            <oxd-chip
-              v-if="comment.edited"
-              :label="$vt('Edited')"
-              class="oxd-comment-edited-chip"
-              :background-color="'#e8eaef'"
-              :color="'#929baa'"
-            />
+            <oxd-chip v-if="comment.edited" :label="$vt('Edited')" class="oxd-comment-edited-chip"
+              :background-color="'#e8eaef'" :color="'#929baa'" />
           </div>
         </div>
       </div>
     </div>
-    <div
-      v-if="deleteMode"
-      ref="commentDeleteWrapper"
-      class="
+    <div v-if="deleteMode" ref="commentDeleteWrapper" class="
         oxd-comment-inline-delete
         d-flex
         align-center
         justify-between
         oxd-mt-5 oxd-p-5
-      "
-      :class="{stacked: stackedMessages}"
-    >
+      " :class="{ stacked: stackConfirmationElements }">
       <div class="comment-inline-delete-content-wrapper d-flex align-center">
         <oxd-text type="subtitle-2">
           {{ commentDeleteConfirmationMsg }}
         </oxd-text>
       </div>
-      <div
-        class="
+      <div class="
           comment-inline-delete-actions-wrapper
           d-flex
           align-center
           oxd-ml-3
-        "
-      >
-        <oxd-button
-          :label="$vt(cancelDeleteButtonData.label)"
-          :iconName="cancelDeleteButtonData.iconName"
-          :iconSize="cancelDeleteButtonData.size"
-          :displayType="cancelDeleteButtonData.displayType"
-          :style="cancelDeleteButtonData.style"
-          :class="cancelDeleteButtonData.class"
-          data-test="deleteButton"
-          @click.once="cancelDeleteButtonData.click"
-        />
-        <oxd-button
-          :label="$vt(confirmDeleteButtonData.label)"
-          :iconName="confirmDeleteButtonData.iconName"
-          :iconSize="confirmDeleteButtonData.size"
-          :displayType="confirmDeleteButtonData.displayType"
-          :style="confirmDeleteButtonData.style"
-          :class="confirmDeleteButtonData.class"
-          data-test="cancelButton"
-          class="oxd-ml-3"
-          @click="confirmDeleteButtonData.click"
-        />
+        ">
+        <oxd-button :label="$vt(cancelDeleteButtonData.label)" :iconName="cancelDeleteButtonData.iconName"
+          :iconSize="cancelDeleteButtonData.size" :displayType="cancelDeleteButtonData.displayType"
+          :style="cancelDeleteButtonData.style" :class="cancelDeleteButtonData.class" data-test="deleteButton"
+          @click.once="cancelDeleteButtonData.click" />
+        <oxd-button :label="$vt(confirmDeleteButtonData.label)" :iconName="confirmDeleteButtonData.iconName"
+          :iconSize="confirmDeleteButtonData.size" :displayType="confirmDeleteButtonData.displayType"
+          :style="confirmDeleteButtonData.style" :class="confirmDeleteButtonData.class" data-test="cancelButton"
+          class="oxd-ml-3" @click="confirmDeleteButtonData.click" />
       </div>
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import {defineComponent, ref, computed, nextTick, watch, PropType} from 'vue';
+import { defineComponent, ref, computed, nextTick, watch, PropType } from 'vue';
 import translateMixin from '../../../mixins/translate';
 import Chip from '@orangehrm/oxd/core/components/Chip/Chip.vue';
 import Label from '@orangehrm/oxd/core/components/Label/Label.vue';
@@ -267,14 +182,14 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
-    stackedMessages: {
+    stackConfirmationElements: {
       type: Boolean as PropType<boolean>,
       default: false,
     },
   },
 
-  setup(props, {emit}) {
-    const {$t} = useTranslate();
+  setup(props, { emit }) {
+    const { $t } = useTranslate();
     const editable = ref(false);
     const invalidCommentUpdate = ref(false);
     const invalidCommentSaveRequired = ref(false);

--- a/components/src/core/components/Comments/Comments.vue
+++ b/components/src/core/components/Comments/Comments.vue
@@ -3,118 +3,59 @@
     <div v-if="showHeaderLabel" class="oxd-comment-header-label-wrapper">
       <oxd-label :label="headerLabel" />
     </div>
-    <div
-      class="oxd-comment-groups-container"
-      v-if="hasCommentsInside || !(hideEmptyPlaceholder || hasCommentsInside)"
-      :class="commentGroupsContainerClasses"
-      :style="commentGroupsContainerStyles"
-    >
-      <div
-        v-if="!(hideEmptyPlaceholder || hasCommentsInside)"
-        class="
+    <div class="oxd-comment-groups-container" v-if="hasCommentsInside || !(hideEmptyPlaceholder || hasCommentsInside)"
+      :class="commentGroupsContainerClasses" :style="commentGroupsContainerStyles">
+      <div v-if="!(hideEmptyPlaceholder || hasCommentsInside)" class="
           oxd-comment-no-notes-found-container
           d-flex
           justify-center
           align-center
-        "
-        :style="{'min-height': `${commentThreadMinHeight}`}"
-      >
+        " :style="{ 'min-height': `${commentThreadMinHeight}` }">
         <div class="oxd-comment-no-notes-found-wrapper">
-          <oxd-icon
-            class="oxd-comment-no-notes-found justify-center"
-            name="oxd-no-notes-found"
-          />
+          <oxd-icon class="oxd-comment-no-notes-found justify-center" name="oxd-no-notes-found" />
           <div class="oxd-comment-no-notes-found-label">
             {{ $vt(emptyPlaceholderMsg) }}
           </div>
         </div>
       </div>
-      <ul
-        ref="commentGroupsList"
-        class="oxd-comment-groups-list"
-        v-if="hasCommentsInside"
-      >
+      <ul ref="commentGroupsList" class="oxd-comment-groups-list" v-if="hasCommentsInside">
         <span class="comments-wrapper" v-if="groupBy == GROUP_BY_TYPE_NONE">
-          <oxd-comment
-            v-for="(comment, commentIndex) in getSortedComments()"
-            :comment="comment"
-            :key="comment || commentIndex"
-            :allowToEdit="
-              disabled || readOnly ? false : allowToEdit || comment.allowToEdit
-            "
-            :allowToDelete="
-              disabled || readOnly
-                ? false
-                : allowToDelete || comment.allowToDelete
-            "
-            :enableAvatar="enableAvatar"
-            :requiredEditCommentErrorMsg="requiredEditCommentErrorMsg"
+          <oxd-comment v-for="(comment, commentIndex) in getSortedComments()" :comment="comment"
+            :key="comment || commentIndex" :allowToEdit="disabled || readOnly ? false : allowToEdit || comment.allowToEdit
+              " :allowToDelete="disabled || readOnly
+      ? false
+      : allowToDelete || comment.allowToDelete
+    " :enableAvatar="enableAvatar" :requiredEditCommentErrorMsg="requiredEditCommentErrorMsg"
             :unsavedEditCommentErrorMsg="unsavedEditCommentErrorMsg"
-            :commentDeleteConfirmationMsg="commentDeleteConfirmationMsg"
-            :maxCharLength="commentEditMaxCharLength"
-            :showGroupNamePill="true"
-            :stackedMessages="stackedMessages"
-            @commentEditHasError="commentEditHasError"
-            @onUpdateComment="onUpdateComment"
-            @onDeleteComment="onDeleteComment"
-          />
+            :commentDeleteConfirmationMsg="commentDeleteConfirmationMsg" :maxCharLength="commentEditMaxCharLength"
+            :showGroupNamePill="true" :stackConfirmationElements="stackConfirmationElements"
+            @commentEditHasError="commentEditHasError" @onUpdateComment="onUpdateComment"
+            @onDeleteComment="onDeleteComment" />
         </span>
-        <span
-          class="comments-group-wrapper"
-          v-if="groupBy == GROUP_BY_TYPE_GROUP"
-        >
-          <li
-            class="oxd-comment-group"
-            v-for="(commentGroup, groupIndex) in commentGroups"
-            :key="commentGroup.id || groupIndex"
-          >
-            <oxd-label
-              v-if="commentGroup.label"
-              :label="commentGroup.label"
-              class="oxd-comment-group-label"
-            />
-            <oxd-comment
-              v-for="(comment, commentIndex) in commentGroup.comments"
-              :comment="comment"
-              :key="comment || commentIndex"
-              :allowToEdit="
-                disabled || readOnly
+        <span class="comments-group-wrapper" v-if="groupBy == GROUP_BY_TYPE_GROUP">
+          <li class="oxd-comment-group" v-for="(commentGroup, groupIndex) in commentGroups"
+            :key="commentGroup.id || groupIndex">
+            <oxd-label v-if="commentGroup.label" :label="commentGroup.label" class="oxd-comment-group-label" />
+            <oxd-comment v-for="(comment, commentIndex) in commentGroup.comments" :comment="comment"
+              :key="comment || commentIndex" :allowToEdit="disabled || readOnly
                   ? false
                   : allowToEdit || comment.allowToEdit
-              "
-              :allowToDelete="
-                disabled || readOnly
-                  ? false
-                  : allowToDelete || comment.allowToDelete
-              "
-              :enableAvatar="enableAvatar"
-              :requiredEditCommentErrorMsg="requiredEditCommentErrorMsg"
+                " :allowToDelete="disabled || readOnly
+      ? false
+      : allowToDelete || comment.allowToDelete
+    " :enableAvatar="enableAvatar" :requiredEditCommentErrorMsg="requiredEditCommentErrorMsg"
               :unsavedEditCommentErrorMsg="unsavedEditCommentErrorMsg"
-              :commentDeleteConfirmationMsg="commentDeleteConfirmationMsg"
-              :maxCharLength="commentEditMaxCharLength"
-              :stackedMessages="stackedMessages"
-              @commentEditHasError="commentEditHasError"
-              @onUpdateComment="onUpdateComment"
-              @onDeleteComment="onDeleteComment"
-            />
+              :commentDeleteConfirmationMsg="commentDeleteConfirmationMsg" :maxCharLength="commentEditMaxCharLength"
+              :stackConfirmationElements="stackConfirmationElements" @commentEditHasError="commentEditHasError"
+              @onUpdateComment="onUpdateComment" @onDeleteComment="onDeleteComment" />
           </li>
         </span>
       </ul>
     </div>
-    <oxd-comment-box
-      v-if="!(readOnly || disabled || hideAddInput)"
-      :label="commentBoxLabel"
-      :labelIcon="'oxd-note'"
-      :actionButtonIcon="'oxd-add'"
-      :actionButtonTooltip="'Add'"
-      :placeholder="commentBoxPlaceholder"
-      :modelValue="comment"
-      :hasError="hasError"
-      :unsavedAddCommentErrorMsg="unsavedAddCommentErrorMsg"
-      :preventAddOnKeyPressEnter="true"
-      @update:modelValue="onInputComment"
-      @addComment="onAddComment"
-    />
+    <oxd-comment-box v-if="!(readOnly || disabled || hideAddInput)" :label="commentBoxLabel" :labelIcon="'oxd-note'"
+      :actionButtonIcon="'oxd-add'" :actionButtonTooltip="'Add'" :placeholder="commentBoxPlaceholder"
+      :modelValue="comment" :hasError="hasError" :unsavedAddCommentErrorMsg="unsavedAddCommentErrorMsg"
+      :preventAddOnKeyPressEnter="true" @update:modelValue="onInputComment" @addComment="onAddComment" />
   </div>
 </template>
 
@@ -250,12 +191,12 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
-    stackedMessages: {
+    stackConfirmationElements: {
       type: Boolean as PropType<boolean>,
       default: false,
     },
   },
-  setup(props, {emit}) {
+  setup(props, { emit }) {
     const commentGroupsList = ref(null);
     const comment = ref<string>('');
 
@@ -288,8 +229,8 @@ export default defineComponent({
         hasCommentsInside.value && props.scrollHeight
           ? props.scrollHeight
           : !props.hideEmptyPlaceholder
-          ? props.scrollHeight
-          : undefined;
+            ? props.scrollHeight
+            : undefined;
       return {
         'min-height':
           !props.hideEmptyPlaceholder && `${props.commentThreadMinHeight}`,

--- a/components/src/core/components/Comments/Comments.vue
+++ b/components/src/core/components/Comments/Comments.vue
@@ -53,6 +53,7 @@
             :commentDeleteConfirmationMsg="commentDeleteConfirmationMsg"
             :maxCharLength="commentEditMaxCharLength"
             :showGroupNamePill="true"
+            :stackedMessages="stackedMessages"
             @commentEditHasError="commentEditHasError"
             @onUpdateComment="onUpdateComment"
             @onDeleteComment="onDeleteComment"
@@ -91,6 +92,7 @@
               :unsavedEditCommentErrorMsg="unsavedEditCommentErrorMsg"
               :commentDeleteConfirmationMsg="commentDeleteConfirmationMsg"
               :maxCharLength="commentEditMaxCharLength"
+              :stackedMessages="stackedMessages"
               @commentEditHasError="commentEditHasError"
               @onUpdateComment="onUpdateComment"
               @onDeleteComment="onDeleteComment"
@@ -247,6 +249,10 @@ export default defineComponent({
     scrollOnLoad: {
       type: Boolean,
       default: true,
+    },
+    stackedMessages: {
+      type: Boolean as PropType<boolean>,
+      default: false,
     },
   },
   setup(props, {emit}) {

--- a/components/src/core/components/Comments/__tests__/comment.spec.ts
+++ b/components/src/core/components/Comments/__tests__/comment.spec.ts
@@ -126,7 +126,7 @@ describe('Comment.vue', () => {
         allowToEdit: false,
         allowToDelete: true,
         enableAvatar: false,
-        stackedMessages: true,
+        stackConfirmationElements: true,
       },
     });
     await wrapper.vm.$nextTick();

--- a/components/src/core/components/Comments/__tests__/comment.spec.ts
+++ b/components/src/core/components/Comments/__tests__/comment.spec.ts
@@ -118,4 +118,23 @@ describe('Comment.vue', () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.find('.oxd-comment-group-name-chip').exists()).toBeTruthy();
   });
+
+  it('Delete confimation message and action buttons are stacked', async () => {
+    const wrapper = mount(Comment, {
+      props: {
+        comment: comment,
+        allowToEdit: false,
+        allowToDelete: true,
+        enableAvatar: false,
+        stackedMessages: true,
+      },
+    });
+    await wrapper.vm.$nextTick();
+    const deleteButton = wrapper.find('[data-test="deleteIcon"]');
+    deleteButton.trigger('click');
+    await wrapper.vm.$nextTick();
+    const inlineDeleteBar = wrapper.find('.oxd-comment-inline-delete');
+    expect(inlineDeleteBar.exists()).toBeTruthy();
+    expect(inlineDeleteBar.classes()).toContain('stacked');
+  });
 });

--- a/components/src/core/components/Comments/comment.scss
+++ b/components/src/core/components/Comments/comment.scss
@@ -142,6 +142,14 @@
   &-inline-delete {
     border-radius: 1.2rem;
     background-color: rgba(235, 9, 16, 0.1);
+    &.stacked {
+      flex-wrap: wrap;
+      .comment-inline-delete-actions-wrapper {
+        margin: 0.5rem 0 0 0;
+        width: 100%;
+        justify-content: flex-end;
+      }
+    }
   }
 }
 

--- a/storybook/stories/core/components/Comments/Comments.stories.js
+++ b/storybook/stories/core/components/Comments/Comments.stories.js
@@ -53,7 +53,7 @@ export default {
       },
     },
 
-    stackedMessages: {
+    stackConfirmationElements: {
       control: {type: 'boolean'},
       defaultValue: false,
       table: {
@@ -294,7 +294,7 @@ Default.args = {
   unsavedAddCommentErrorMsg: 'Comment should be either updated or removed',
   commentDeleteConfirmationMsg:
     'The current comment will be permanently deleted. Are you sure you want to continue?',
-  stackedMessages: false,
+  stackConfirmationElements: false,
 };
 
 export const ScrollSettings = Template.bind({});
@@ -309,7 +309,7 @@ ScrollSettings.args = {
     mode: SMOOTH,
     scrollTo: END,
   },
-  stackedMessages: false,
+  stackConfirmationElements: false,
 };
 
 export const ReadOnly = Template.bind({});
@@ -321,7 +321,7 @@ ReadOnly.args = {
   enableAvatar: true,
   scrollHeight: '350px',
   readOnly: true,
-  stackedMessages: false,
+  stackConfirmationElements: false,
 };
 
 export const HideAddInput = Template.bind({});
@@ -333,7 +333,7 @@ HideAddInput.args = {
   enableAvatar: true,
   scrollHeight: '350px',
   hideAddInput: true,
-  stackedMessages: false,
+  stackConfirmationElements: false,
 };
 
 export const Disabled = Template.bind({});
@@ -345,7 +345,7 @@ Disabled.args = {
   enableAvatar: true,
   scrollHeight: '350px',
   disabled: true,
-  stackedMessages: false,
+  stackConfirmationElements: false,
 };
 
 export const EmptyCommentsWithPlaceholder = Template.bind({});
@@ -356,7 +356,7 @@ EmptyCommentsWithPlaceholder.args = {
   enableAvatar: true,
   scrollHeight: '500px',
   commentThreadMinHeight: '500px',
-  stackedMessages: false,
+  stackConfirmationElements: false,
 };
 
 export const EmptyCommentsWithoutPlaceholder = Template.bind({});
@@ -367,7 +367,7 @@ EmptyCommentsWithoutPlaceholder.args = {
   enableAvatar: true,
   scrollHeight: '300px',
   hideEmptyPlaceholder: true,
-  stackedMessages: false,
+  stackConfirmationElements: false,
 };
 
 export const WithHeaderLabel = Template.bind({});
@@ -379,7 +379,7 @@ WithHeaderLabel.args = {
   allowToDelete: true,
   enableAvatar: true,
   scrollHeight: '300px',
-  stackedMessages: false,
+  stackConfirmationElements: false,
 };
 
 const TemplateSchema = (args) => ({
@@ -419,7 +419,7 @@ const sample = {
               allowToEdit: false,
               allowToDelete: false,
               enableAvatar: true,
-              stackedMessages: false,
+              stackConfirmationElements: false,
               scrollHeight: '250px',
             },
             listeners: {
@@ -471,7 +471,7 @@ Default.parameters = {
       <oxd-comments
         :enableAvatar="true"
         :scrollHeight="200"
-        :stackedMessages="false"
+        :stackConfirmationElements="false"
         :commentGroups="commentGroups"
         :commentDeleteConfirmationMsg=""The current comment will be permanently deleted. Are you sure you want to continue?"
         @onAddComment="addComment"

--- a/storybook/stories/core/components/Comments/Comments.stories.js
+++ b/storybook/stories/core/components/Comments/Comments.stories.js
@@ -52,6 +52,18 @@ export default {
         },
       },
     },
+
+    stackedMessages: {
+      control: {type: 'boolean'},
+      defaultValue: false,
+      table: {
+        type: {
+          summary:
+            'Set boolean value to change inline delete confirmation message and action buttons into stacked view',
+        },
+      },
+    },
+
     scrollHeight: {
       control: {type: 'text'},
       defaultValue: 0,
@@ -282,6 +294,7 @@ Default.args = {
   unsavedAddCommentErrorMsg: 'Comment should be either updated or removed',
   commentDeleteConfirmationMsg:
     'The current comment will be permanently deleted. Are you sure you want to continue?',
+  stackedMessages: false,
 };
 
 export const ScrollSettings = Template.bind({});
@@ -296,6 +309,7 @@ ScrollSettings.args = {
     mode: SMOOTH,
     scrollTo: END,
   },
+  stackedMessages: false,
 };
 
 export const ReadOnly = Template.bind({});
@@ -307,6 +321,7 @@ ReadOnly.args = {
   enableAvatar: true,
   scrollHeight: '350px',
   readOnly: true,
+  stackedMessages: false,
 };
 
 export const HideAddInput = Template.bind({});
@@ -318,6 +333,7 @@ HideAddInput.args = {
   enableAvatar: true,
   scrollHeight: '350px',
   hideAddInput: true,
+  stackedMessages: false,
 };
 
 export const Disabled = Template.bind({});
@@ -329,6 +345,7 @@ Disabled.args = {
   enableAvatar: true,
   scrollHeight: '350px',
   disabled: true,
+  stackedMessages: false,
 };
 
 export const EmptyCommentsWithPlaceholder = Template.bind({});
@@ -339,6 +356,7 @@ EmptyCommentsWithPlaceholder.args = {
   enableAvatar: true,
   scrollHeight: '500px',
   commentThreadMinHeight: '500px',
+  stackedMessages: false,
 };
 
 export const EmptyCommentsWithoutPlaceholder = Template.bind({});
@@ -349,6 +367,7 @@ EmptyCommentsWithoutPlaceholder.args = {
   enableAvatar: true,
   scrollHeight: '300px',
   hideEmptyPlaceholder: true,
+  stackedMessages: false,
 };
 
 export const WithHeaderLabel = Template.bind({});
@@ -360,6 +379,7 @@ WithHeaderLabel.args = {
   allowToDelete: true,
   enableAvatar: true,
   scrollHeight: '300px',
+  stackedMessages: false,
 };
 
 const TemplateSchema = (args) => ({
@@ -399,6 +419,7 @@ const sample = {
               allowToEdit: false,
               allowToDelete: false,
               enableAvatar: true,
+              stackedMessages: false,
               scrollHeight: '250px',
             },
             listeners: {
@@ -450,6 +471,7 @@ Default.parameters = {
       <oxd-comments
         :enableAvatar="true"
         :scrollHeight="200"
+        :stackedMessages="false"
         :commentGroups="commentGroups"
         :commentDeleteConfirmationMsg=""The current comment will be permanently deleted. Are you sure you want to continue?"
         @onAddComment="addComment"


### PR DESCRIPTION

![Screenshot from 2023-05-09 18-50-55](https://github.com/orangehrm/oxd/assets/33354992/8e13db0c-91d8-4a03-8395-fa68f90aa8f5)

![Screenshot from 2023-05-09 18-51-20](https://github.com/orangehrm/oxd/assets/33354992/993ed72d-f3a0-4651-80ec-18676c99f350)


## Checklist

- [x] Test Coverage is 100% for the newly added code
- [x] Storybook stories are added/updated for the changed areas
- [x] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
