### PR TITLE
Add border-radius style to Calendar Widget when the date is a non-working-day and selected

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+2023-10-03 - a06c8f9059ceb16ba00c4bf8bf0528ea2c9cee22 - Add border-radius style to Calendar component when the date is a non-working-day and selected.
+
 2023-09-04 - d72a759e6904d11d222b62a792aa8c5f622238cf - Update ListTable.vue component to show partial loading status.
 
 2023-07-18 - c9c95369854606181469c76d7d621008af6946b3 - Update CardTable/Cell/ProfilePicture.vue ProfilePic.vue to support skeleton loading images.

--- a/components/src/core/components/Calendar/calendar.scss
+++ b/components/src/core/components/Calendar/calendar.scss
@@ -77,12 +77,20 @@
       color: $oxd-calendar-date-half-font-color;
       font-weight: $oxd-calendar-date-half-font-weight;
       border-radius: 0;
+
+      &.--selected {
+        border-radius: $oxd-calendar-date-border-radius;
+      }
     }
     &.--non-working-day {
       background-color: $oxd-calendar-date-weekend-background-color;
       color: $oxd-calendar-date-weekend-font-color;
       font-weight: $oxd-calendar-date-weekend-font-weight;
       border-radius: 0;
+      
+      &.--selected {
+        border-radius: $oxd-calendar-date-border-radius;
+      }
     }
     &.--holiday-half {
       background-color: $oxd-calendar-date-holiday-half-background-color;


### PR DESCRIPTION
## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [x] Changelog.md updated on possible breaking (applicable to ent branch)
