### PR TITLE
LAN 1050 fixes - In comment component oxd alert component was used in…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+2024-04-09 - 2b3e650eecb38e9f3ea731e84f167d7c950a641a - Comments/Comment.vue - Hardcoded delete warning is replaced by oxd-alert warning
+
 2024-03-21 - 8319dbeeb35e6aa50fb955ea075ebea5ba30bf43 - ListTable/ListTable.vue - Table header truncate improvments
 
 2024-03-18 - 0ed25f1c3db3b364dc31874362c6455af008be80 - directives/focus-first-element - Focus first directive prevent scroll on focus

--- a/components/src/core/components/Comments/Comment.vue
+++ b/components/src/core/components/Comments/Comment.vue
@@ -147,13 +147,12 @@
     <div v-if="deleteMode" ref="commentDeleteWrapper">
       <oxd-alert
         :message="$vt(commentDeleteConfirmationMsg)"
-        :type="alertType"
+        :type="'error'"
         :show="deleteMode"
         :compact="stackConfirmationElements"
       >
         <oxd-button
           :label="$vt(cancelDeleteButtonData.label)"
-          :iconName="cancelDeleteButtonData.iconName"
           :iconSize="cancelDeleteButtonData.size"
           :displayType="cancelDeleteButtonData.displayType"
           :style="cancelDeleteButtonData.style"
@@ -163,7 +162,6 @@
         />
         <oxd-button
           :label="$vt(confirmDeleteButtonData.label)"
-          :iconName="confirmDeleteButtonData.iconName"
           :iconSize="confirmDeleteButtonData.size"
           :displayType="confirmDeleteButtonData.displayType"
           :style="confirmDeleteButtonData.style"
@@ -254,10 +252,6 @@ export default defineComponent({
     stackConfirmationElements: {
       type: Boolean as PropType<boolean>,
       default: false,
-    },
-    alertType: {
-      type: String,
-      default: 'error',
     },
   },
 
@@ -408,7 +402,6 @@ export default defineComponent({
     const confirmDeleteButtonData = computed(() => {
       const initialObject = {
         label: 'Yes, Delete',
-        iconName: null,
         size: 'medium',
         displayType: 'danger',
         style: null,
@@ -427,7 +420,6 @@ export default defineComponent({
     const cancelDeleteButtonData = computed(() => {
       const initialObject = {
         label: 'No, Cancel',
-        iconName: null,
         size: 'medium',
         displayType: 'ghost-danger',
         style: null,

--- a/components/src/core/components/Comments/Comment.vue
+++ b/components/src/core/components/Comments/Comment.vue
@@ -144,30 +144,12 @@
         </div>
       </div>
     </div>
-    <div
-      v-if="deleteMode"
-      ref="commentDeleteWrapper"
-      class="
-        oxd-comment-inline-delete
-        d-flex
-        align-center
-        justify-between
-        oxd-mt-5 oxd-p-5
-      "
-      :class="{stacked: stackConfirmationElements}"
-    >
-      <div class="comment-inline-delete-content-wrapper d-flex align-center">
-        <oxd-text type="subtitle-2">
-          {{ commentDeleteConfirmationMsg }}
-        </oxd-text>
-      </div>
-      <div
-        class="
-          comment-inline-delete-actions-wrapper
-          d-flex
-          align-center
-          oxd-ml-3
-        "
+    <div v-if="deleteMode" ref="commentDeleteWrapper">
+      <oxd-alert
+        :message="$vt(commentDeleteConfirmationMsg)"
+        :type="alertType"
+        :show="deleteMode"
+        :compact="stackConfirmationElements"
       >
         <oxd-button
           :label="$vt(cancelDeleteButtonData.label)"
@@ -190,7 +172,7 @@
           class="oxd-ml-3"
           @click="confirmDeleteButtonData.click"
         />
-      </div>
+      </oxd-alert>
     </div>
   </div>
 </template>
@@ -205,6 +187,7 @@ import ProfilePic from '@orangehrm/oxd/core/components/ProfilePic/ProfilePic.vue
 import CommentBox from '@orangehrm/oxd/core/components/Comments/CommentBox.vue';
 import IconButton from '@orangehrm/oxd/core/components/Button/Icon.vue';
 import oxdButton from '@orangehrm/oxd/core/components/Button/Button.vue';
+import oxdAlert from '@orangehrm/oxd/core/components/Alert/Alert.vue';
 import useTranslate from '../../../composables/useTranslate';
 
 export default defineComponent({
@@ -220,6 +203,7 @@ export default defineComponent({
     'oxd-comment-box': CommentBox,
     'oxd-text': oxdText,
     'oxd-button': oxdButton,
+    'oxd-alert': oxdAlert,
   },
 
   props: {
@@ -270,6 +254,10 @@ export default defineComponent({
     stackConfirmationElements: {
       type: Boolean as PropType<boolean>,
       default: false,
+    },
+    alertType: {
+      type: String,
+      default: 'error',
     },
   },
 
@@ -420,7 +408,7 @@ export default defineComponent({
     const confirmDeleteButtonData = computed(() => {
       const initialObject = {
         label: 'Yes, Delete',
-        iconName: 'oxd-trash',
+        iconName: null,
         size: 'medium',
         displayType: 'danger',
         style: null,
@@ -438,7 +426,7 @@ export default defineComponent({
 
     const cancelDeleteButtonData = computed(() => {
       const initialObject = {
-        label: 'Cancel',
+        label: 'No, Cancel',
         iconName: null,
         size: 'medium',
         displayType: 'ghost-danger',

--- a/components/src/core/components/Comments/__tests__/comment.spec.ts
+++ b/components/src/core/components/Comments/__tests__/comment.spec.ts
@@ -28,14 +28,14 @@ describe('Comment.vue', () => {
         enableAvatar: false,
         okButton: {
           label: 'Yes, Delete',
-          iconName: 'oxd-trash',
+          iconName: null,
           size: 'medium',
           displayType: 'warn',
           style: null,
           class: null,
         },
         cancelButton: {
-          label: 'Cancel',
+          label: 'No, Cancel',
           iconName: null,
           size: 'medium',
           displayType: 'ghost-warn',
@@ -119,6 +119,26 @@ describe('Comment.vue', () => {
     expect(wrapper.find('.oxd-comment-group-name-chip').exists()).toBeTruthy();
   });
 
+  it('With error alert type', async () => {
+    const wrapper = mount(Comment, {
+      props: {
+        comment: comment,
+        allowToEdit: false,
+        allowToDelete: true,
+        enableAvatar: false,
+        stackConfirmationElements: false,
+        alertType: 'error'
+      },
+    });
+    await wrapper.vm.$nextTick();
+    const deleteButton = wrapper.find('[data-test="deleteIcon"]');
+    deleteButton.trigger('click');
+    await wrapper.vm.$nextTick();
+    const errorAlert = wrapper.find('.oxd-alert-content--error');
+    expect(errorAlert.exists()).toBeTruthy();
+    expect(errorAlert.classes()).toContain(["oxd-alert-content", "oxd-alert-content--error"]);
+  });
+
   it('Delete confimation message and action buttons are stacked', async () => {
     const wrapper = mount(Comment, {
       props: {
@@ -133,8 +153,8 @@ describe('Comment.vue', () => {
     const deleteButton = wrapper.find('[data-test="deleteIcon"]');
     deleteButton.trigger('click');
     await wrapper.vm.$nextTick();
-    const inlineDeleteBar = wrapper.find('.oxd-comment-inline-delete');
+    const inlineDeleteBar = wrapper.find('.oxd-alert-content--compact');
     expect(inlineDeleteBar.exists()).toBeTruthy();
-    expect(inlineDeleteBar.classes()).toContain('stacked');
+    expect(inlineDeleteBar.classes()).toContain(["oxd-alert-content", "oxd-alert-content--error", "oxd-alert-content--compact"]);
   });
 });

--- a/components/src/core/components/Comments/__tests__/comment.spec.ts
+++ b/components/src/core/components/Comments/__tests__/comment.spec.ts
@@ -127,7 +127,6 @@ describe('Comment.vue', () => {
         allowToDelete: true,
         enableAvatar: false,
         stackConfirmationElements: false,
-        alertType: 'error'
       },
     });
     await wrapper.vm.$nextTick();

--- a/components/src/core/components/Comments/__tests__/comment.spec.ts
+++ b/components/src/core/components/Comments/__tests__/comment.spec.ts
@@ -136,7 +136,6 @@ describe('Comment.vue', () => {
     await wrapper.vm.$nextTick();
     const errorAlert = wrapper.find('.oxd-alert-content--error');
     expect(errorAlert.exists()).toBeTruthy();
-    expect(errorAlert.classes()).toContain(["oxd-alert-content", "oxd-alert-content--error"]);
   });
 
   it('Delete confimation message and action buttons are stacked', async () => {
@@ -155,6 +154,5 @@ describe('Comment.vue', () => {
     await wrapper.vm.$nextTick();
     const inlineDeleteBar = wrapper.find('.oxd-alert-content--compact');
     expect(inlineDeleteBar.exists()).toBeTruthy();
-    expect(inlineDeleteBar.classes()).toContain(["oxd-alert-content", "oxd-alert-content--error", "oxd-alert-content--compact"]);
   });
 });


### PR DESCRIPTION
…stead of hardcoded alert

## Checklist

- [x] Test Coverage is 100% for the newly added code
- [x] Storybook stories are added/updated for the changed areas
- [x] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [x] Changelog.md updated on possible breaking (applicable to ent branch)
