### PR TITLE
LAN 1191 : Fix the progress value to 2 decimals in LinearProgress component

### DIFF
--- a/components/src/core/components/LinearProgress/LinearProgress.vue
+++ b/components/src/core/components/LinearProgress/LinearProgress.vue
@@ -52,7 +52,7 @@ export default defineComponent({
   setup: function(props) {
     const progressPercentage = computed(() => {
       if (props.progressValue > 0)
-        return `${Math.min(props.progressValue, 100)}%`;
+        return `${Math.min(Number(props.progressValue.toFixed(2)), 100)}%`;
       return '0%';
     });
 

--- a/components/src/core/components/LinearProgress/__tests__/linearProgress.spec.ts
+++ b/components/src/core/components/LinearProgress/__tests__/linearProgress.spec.ts
@@ -14,7 +14,7 @@ describe('LinearProgress.vue', () => {
 
   it('renders OXD LinearProgress with custom value', () => {
     const wrapper = mount(LinearProgress, {
-      props: {progressValue: '60'},
+      props: {progressValue: 60},
     });
     expect(
       wrapper.find('.oxd-linear-progress-inner').attributes('style'),
@@ -91,6 +91,24 @@ describe('LinearProgress.vue', () => {
     });
     expect(wrapper.find('.oxd-linear-progress-value').text()).toStrictEqual(
       '0%',
+    );
+  });
+
+  it('when the percentage value is having decimal values', () => {
+    const wrapper = mount(LinearProgress, {
+      props: {progressValue: 5.78, showPercentageValue: true},
+    });
+    expect(wrapper.find('.oxd-linear-progress-value').text()).toStrictEqual(
+      '5.78%',
+    );
+  });
+
+  it('when the percentage value is having decimal values than 2 decimals', () => {
+    const wrapper = mount(LinearProgress, {
+      props: {progressValue: 5.7893883, showPercentageValue: true},
+    });
+    expect(wrapper.find('.oxd-linear-progress-value').text()).toStrictEqual(
+      '5.79%',
     );
   });
 });


### PR DESCRIPTION
## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [ ] Code is linted properly
- [ ] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
