### PR TITLE
ROS-336: Fix calendar to show default visible month based on min/max values

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-2025-09-19 - 14f4409c441fd3f22464620dfe9cf017de65756d - components/src/core/components/Calendar/Calendar.vue - Fix calendar to default visible month based on min/max values.
+2025-09-19 - da08b5e9e5bfed360d38bfa495511ff23017340e - components/src/core/components/Calendar/Calendar.vue - Fix calendar to default visible month based on min/max values.
 
 2025-09-19 - 90636c51312cc3ff8cdc87298c43471b20cdff4a - components/src/core/components/Icon/icons.ts - Add oxd-print icon
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
+2025-09-19 - 14f4409c441fd3f22464620dfe9cf017de65756d - components/src/core/components/Calendar/Calendar.vue - Fix calendar to default visible month based on min/max values.
+
 2025-09-19 - 90636c51312cc3ff8cdc87298c43471b20cdff4a - components/src/core/components/Icon/icons.ts - Add oxd-print icon
 
-2025-08-22- 390b3a08bddd39d4511c8a1ffd1bf3dd2e90b7c1 - components/src/core/components/Input/Autocomplete/AutocompleteInput.vue - Pass selected options to createOptions function enabling developers to filter already selected options
+2025-08-22 - 390b3a08bddd39d4511c8a1ffd1bf3dd2e90b7c1 - components/src/core/components/Input/Autocomplete/AutocompleteInput.vue - Pass selected options to createOptions function enabling developers to filter already selected options
 
 2025-08-19 - 3dc9a8853d02cb4d9fafa12986b9234ffb8d42a8 - components/src/core/components/Icon/icons.ts - Added icons : oxd-multi-user-2, oxd-logs-list, oxd-created-date, oxd-modified-date
 

--- a/components/src/core/components/Calendar/Calendar.vue
+++ b/components/src/core/components/Calendar/Calendar.vue
@@ -32,7 +32,7 @@ export default defineComponent({
     modelValue: {
       type: Object as PropType<Date>,
       default: () => {
-        return freshDate();
+        return undefined;
       },
     },
     firstDayOfWeek: {
@@ -84,16 +84,59 @@ export default defineComponent({
     },
   },
   setup(props, context) {
+    const modifiedModelValue = props.modelValue || freshDate();
+
     const selectedDate = computed(() => {
-      return props.modelValue
-        ? new Date(props.modelValue.setHours(0, 0, 0, 0))
-        : props.modelValue;
+      return modifiedModelValue
+        ? new Date(modifiedModelValue.setHours(0, 0, 0, 0))
+        : modifiedModelValue;
     });
 
-    const state = reactive({
-      year: getYear(selectedDate.value || new Date()),
-      month: getMonth(selectedDate.value || new Date()),
-    });
+    const calculateInitialMonth = () => {
+      // If modelValue exists, use its month/year regardless of min/max constraints
+      if (props.modelValue) {
+        const targetYear = getYear(props.modelValue);
+        const targetMonth = getMonth(props.modelValue);
+        return {year: targetYear, month: targetMonth};
+      }
+
+      // If no modelValue, use current date and apply min/max constraints
+      let targetYear = getYear(modifiedModelValue);
+      let targetMonth = getMonth(modifiedModelValue);
+
+      // Create a date for the first day of the target month for comparison
+      const targetMonthDate = new Date(targetYear, targetMonth, 1);
+
+      // If min is set and target month is before min, use min's month
+      if (props.min) {
+        const minMonthDate = new Date(
+          getYear(props.min),
+          getMonth(props.min),
+          1,
+        );
+        if (targetMonthDate < minMonthDate) {
+          targetYear = getYear(props.min);
+          targetMonth = getMonth(props.min);
+        }
+      }
+
+      // If max is set and target month is after max, use max's month
+      if (props.max) {
+        const maxMonthDate = new Date(
+          getYear(props.max),
+          getMonth(props.max),
+          1,
+        );
+        if (targetMonthDate > maxMonthDate) {
+          targetYear = getYear(props.max);
+          targetMonth = getMonth(props.max);
+        }
+      }
+
+      return {year: targetYear, month: targetMonth};
+    };
+
+    const state = reactive(calculateInitialMonth());
 
     const daysOfWeek = computed(() => {
       let days = JSON.parse(JSON.stringify(props.days));

--- a/components/src/core/components/Calendar/Calendar.vue
+++ b/components/src/core/components/Calendar/Calendar.vue
@@ -30,7 +30,7 @@ export default defineComponent({
   name: 'oxd-calendar',
   props: {
     modelValue: {
-      type: Object as PropType<Date>,
+      type: Object as PropType<Date | undefined>,
       default: () => {
         return undefined;
       },
@@ -84,56 +84,47 @@ export default defineComponent({
     },
   },
   setup(props, context) {
-    const modifiedModelValue = props.modelValue || freshDate();
-
     const selectedDate = computed(() => {
-      return modifiedModelValue
-        ? new Date(modifiedModelValue.setHours(0, 0, 0, 0))
-        : modifiedModelValue;
+      const value = props.modelValue || freshDate();
+      return value ? new Date(value.setHours(0, 0, 0, 0)) : value;
     });
 
     const calculateInitialMonth = () => {
-      // If modelValue exists, use its month/year regardless of min/max constraints
+      const getMonthStart = (date: Date) =>
+        new Date(getYear(date), getMonth(date), 1);
+
+      // If modelValue exists, always prefer it
       if (props.modelValue) {
-        const targetYear = getYear(props.modelValue);
-        const targetMonth = getMonth(props.modelValue);
-        return {year: targetYear, month: targetMonth};
+        return {
+          year: getYear(props.modelValue),
+          month: getMonth(props.modelValue),
+        };
       }
 
-      // If no modelValue, use current date and apply min/max constraints
-      let targetYear = getYear(modifiedModelValue);
-      let targetMonth = getMonth(modifiedModelValue);
+      const currentMonthSart = getMonthStart(selectedDate.value);
 
-      // Create a date for the first day of the target month for comparison
-      const targetMonthDate = new Date(targetYear, targetMonth, 1);
-
-      // If min is set and target month is before min, use min's month
-      if (props.min) {
-        const minMonthDate = new Date(
-          getYear(props.min),
-          getMonth(props.min),
-          1,
-        );
-        if (targetMonthDate < minMonthDate) {
-          targetYear = getYear(props.min);
-          targetMonth = getMonth(props.min);
-        }
+      // If min is set and current date is before min → return min's year and month
+      if (props.min && currentMonthSart < getMonthStart(props.min)) {
+        return {
+          year: getYear(props.min),
+          month: getMonth(props.min),
+        };
       }
 
-      // If max is set and target month is after max, use max's month
-      if (props.max) {
-        const maxMonthDate = new Date(
-          getYear(props.max),
-          getMonth(props.max),
-          1,
-        );
-        if (targetMonthDate > maxMonthDate) {
-          targetYear = getYear(props.max);
-          targetMonth = getMonth(props.max);
-        }
+      // If max is set and current date is after max → return max's year and month
+      if (props.max && currentMonthSart > getMonthStart(props.max)) {
+        return {
+          year: getYear(props.max),
+          month: getMonth(props.max),
+        };
       }
 
-      return {year: targetYear, month: targetMonth};
+      // Otherwise return the current date's month
+      // When there are no min/max constraints OR current date is within min/max constraints
+      return {
+        year: getYear(currentMonthSart),
+        month: getMonth(currentMonthSart),
+      };
     };
 
     const state = reactive(calculateInitialMonth());

--- a/components/src/core/components/Calendar/Calendar.vue
+++ b/components/src/core/components/Calendar/Calendar.vue
@@ -101,10 +101,10 @@ export default defineComponent({
         };
       }
 
-      const currentMonthSart = getMonthStart(selectedDate.value);
+      const currentMonthStart = getMonthStart(selectedDate.value);
 
       // If min is set and current date is before min → return min's year and month
-      if (props.min && currentMonthSart < getMonthStart(props.min)) {
+      if (props.min && currentMonthStart < getMonthStart(props.min)) {
         return {
           year: getYear(props.min),
           month: getMonth(props.min),
@@ -112,7 +112,7 @@ export default defineComponent({
       }
 
       // If max is set and current date is after max → return max's year and month
-      if (props.max && currentMonthSart > getMonthStart(props.max)) {
+      if (props.max && currentMonthStart > getMonthStart(props.max)) {
         return {
           year: getYear(props.max),
           month: getMonth(props.max),
@@ -122,8 +122,8 @@ export default defineComponent({
       // Otherwise return the current date's month
       // When there are no min/max constraints OR current date is within min/max constraints
       return {
-        year: getYear(currentMonthSart),
-        month: getMonth(currentMonthSart),
+        year: getYear(currentMonthStart),
+        month: getMonth(currentMonthStart),
       };
     };
 

--- a/components/src/core/components/Calendar/__tests__/calendar.spec.ts
+++ b/components/src/core/components/Calendar/__tests__/calendar.spec.ts
@@ -99,4 +99,423 @@ describe('Calendar.vue', () => {
     await wrapper.findComponent(Icon).trigger('click');
     expect(wrapper.emitted('selectYear')).toBeTruthy();
   });
+
+  describe('calculateInitialMonth behavior', () => {
+    describe('without min/max props', () => {
+      it('should show the current month when no modelValue is provided', () => {
+        const currentDate = new Date();
+        const wrapper = mount(Calendar, {});
+
+        expect(wrapper.vm.year).toBe(currentDate.getFullYear());
+        expect(wrapper.vm.month).toBe(currentDate.getMonth());
+      });
+
+      it('should show the month of modelValue when provided', () => {
+        const testDate = new Date(2023, 5, 15); // June 15, 2023
+        const wrapper = mount(Calendar, {
+          props: {
+            modelValue: testDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(2023);
+        expect(wrapper.vm.month).toBe(5); // June (0-based)
+      });
+
+      it('should show current month when modelValue equals current date', () => {
+        const currentDate = freshDate();
+        const wrapper = mount(Calendar, {
+          props: {
+            modelValue: currentDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(currentDate.getFullYear());
+        expect(wrapper.vm.month).toBe(currentDate.getMonth());
+      });
+    });
+
+    describe('with min prop only', () => {
+      it('should show current month when current month is after min', () => {
+        const currentDate = new Date();
+        const minDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() - 2,
+          1,
+        ); // 2 months before current
+
+        const wrapper = mount(Calendar, {
+          props: {
+            min: minDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(currentDate.getFullYear());
+        expect(wrapper.vm.month).toBe(currentDate.getMonth());
+      });
+
+      it('should show current month when current month equals min month', () => {
+        const currentDate = new Date();
+        const minDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth(),
+          1,
+        ); // Same month as current
+
+        const wrapper = mount(Calendar, {
+          props: {
+            min: minDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(currentDate.getFullYear());
+        expect(wrapper.vm.month).toBe(currentDate.getMonth());
+      });
+
+      it('should show min month when current month is before min', () => {
+        const currentDate = new Date();
+        const minDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() + 2,
+          1,
+        ); // 2 months after current
+
+        const wrapper = mount(Calendar, {
+          props: {
+            min: minDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(minDate.getFullYear());
+        expect(wrapper.vm.month).toBe(minDate.getMonth());
+      });
+
+      it('should show modelValue month even when modelValue is before min', () => {
+        const modelDate = new Date(2023, 2, 15); // March 15, 2023
+        const minDate = new Date(2023, 5, 1); // June 1, 2023
+
+        const wrapper = mount(Calendar, {
+          props: {
+            modelValue: modelDate,
+            min: minDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(2023);
+        expect(wrapper.vm.month).toBe(2); // March (0-based) - modelValue takes precedence
+      });
+    });
+
+    describe('with max prop only', () => {
+      it('should show current month when current month is before max', () => {
+        const currentDate = new Date();
+        const maxDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() + 2,
+          15,
+        ); // 2 months after current
+
+        const wrapper = mount(Calendar, {
+          props: {
+            max: maxDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(currentDate.getFullYear());
+        expect(wrapper.vm.month).toBe(currentDate.getMonth());
+      });
+
+      it('should show current month when current month equals max month', () => {
+        const currentDate = new Date();
+        const maxDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth(),
+          15,
+        ); // Same month as current
+
+        const wrapper = mount(Calendar, {
+          props: {
+            max: maxDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(currentDate.getFullYear());
+        expect(wrapper.vm.month).toBe(currentDate.getMonth());
+      });
+
+      it('should show max month when current month is after max', () => {
+        const currentDate = new Date();
+        const maxDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() - 2,
+          15,
+        ); // 2 months before current
+
+        const wrapper = mount(Calendar, {
+          props: {
+            max: maxDate,
+            modelValue: undefined,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(maxDate.getFullYear());
+        expect(wrapper.vm.month).toBe(maxDate.getMonth());
+      });
+
+      it('should show modelValue month even when modelValue is after max', () => {
+        const modelDate = new Date(2023, 8, 15); // September 15, 2023
+        const maxDate = new Date(2023, 5, 30); // June 30, 2023
+
+        const wrapper = mount(Calendar, {
+          props: {
+            modelValue: modelDate,
+            max: maxDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(2023);
+        expect(wrapper.vm.month).toBe(8); // September (0-based) - modelValue takes precedence
+      });
+    });
+
+    describe('with both min and max props', () => {
+      it('should show current month when current is within min-max range', () => {
+        const currentDate = new Date();
+        const minDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() - 1,
+          1,
+        ); // 1 month before
+        const maxDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() + 1,
+          30,
+        ); // 1 month after
+
+        const wrapper = mount(Calendar, {
+          props: {
+            min: minDate,
+            max: maxDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(currentDate.getFullYear());
+        expect(wrapper.vm.month).toBe(currentDate.getMonth());
+      });
+
+      it('should show min month when current is before min', () => {
+        const currentDate = new Date();
+        const minDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() + 1,
+          1,
+        ); // 1 month after current
+        const maxDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() + 3,
+          30,
+        ); // 3 months after current
+
+        const wrapper = mount(Calendar, {
+          props: {
+            min: minDate,
+            max: maxDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(minDate.getFullYear());
+        expect(wrapper.vm.month).toBe(minDate.getMonth());
+      });
+
+      it('should show max month when current is after max', () => {
+        const currentDate = new Date();
+        const minDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() - 3,
+          1,
+        ); // 3 months before current
+        const maxDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() - 1,
+          30,
+        ); // 1 month before current
+
+        const wrapper = mount(Calendar, {
+          props: {
+            min: minDate,
+            max: maxDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(maxDate.getFullYear());
+        expect(wrapper.vm.month).toBe(maxDate.getMonth());
+      });
+
+      it('should show modelValue month when within range', () => {
+        const modelDate = new Date(2023, 4, 15); // May 15, 2023
+        const minDate = new Date(2023, 2, 1); // March 1, 2023
+        const maxDate = new Date(2023, 7, 30); // August 30, 2023
+
+        const wrapper = mount(Calendar, {
+          props: {
+            modelValue: modelDate,
+            min: minDate,
+            max: maxDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(2023);
+        expect(wrapper.vm.month).toBe(4); // May (0-based)
+      });
+
+      it('should show modelValue month even when modelValue is before min', () => {
+        const modelDate = new Date(2023, 1, 15); // February 15, 2023
+        const minDate = new Date(2023, 3, 1); // April 1, 2023
+        const maxDate = new Date(2023, 7, 30); // August 30, 2023
+
+        const wrapper = mount(Calendar, {
+          props: {
+            modelValue: modelDate,
+            min: minDate,
+            max: maxDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(2023);
+        expect(wrapper.vm.month).toBe(1); // February (0-based) - modelValue takes precedence
+      });
+
+      it('should show modelValue month even when modelValue is after max', () => {
+        const modelDate = new Date(2023, 9, 15); // October 15, 2023
+        const minDate = new Date(2023, 2, 1); // March 1, 2023
+        const maxDate = new Date(2023, 6, 30); // July 30, 2023
+
+        const wrapper = mount(Calendar, {
+          props: {
+            modelValue: modelDate,
+            min: minDate,
+            max: maxDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(2023);
+        expect(wrapper.vm.month).toBe(9); // October (0-based) - modelValue takes precedence
+      });
+    });
+
+    describe('when modelValue equals current date', () => {
+      it('should show modelValue month when modelValue equals current date and current is before min', () => {
+        const currentDate = freshDate();
+        const minDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() + 2,
+          1,
+        ); // 2 months after current
+
+        const wrapper = mount(Calendar, {
+          props: {
+            modelValue: currentDate,
+            min: minDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(currentDate.getFullYear());
+        expect(wrapper.vm.month).toBe(currentDate.getMonth());
+      });
+
+      it('should show modelValue month when modelValue equals current date and current is after max', () => {
+        const currentDate = freshDate();
+        const maxDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() - 2,
+          15,
+        ); // 2 months before current
+
+        const wrapper = mount(Calendar, {
+          props: {
+            modelValue: currentDate,
+            max: maxDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(currentDate.getFullYear());
+        expect(wrapper.vm.month).toBe(currentDate.getMonth());
+      });
+
+      it('should show current month when modelValue equals current date and current is within min-max range', () => {
+        const currentDate = freshDate();
+        const minDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() - 1,
+          1,
+        ); // 1 month before current
+        const maxDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() + 1,
+          30,
+        ); // 1 month after current
+
+        const wrapper = mount(Calendar, {
+          props: {
+            modelValue: currentDate,
+            min: minDate,
+            max: maxDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(currentDate.getFullYear());
+        expect(wrapper.vm.month).toBe(currentDate.getMonth());
+      });
+
+      it('should show modelValue month when modelValue equals current date and current is before min with both constraints', () => {
+        const currentDate = freshDate();
+        const minDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() + 1,
+          1,
+        ); // 1 month after current
+        const maxDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() + 3,
+          30,
+        ); // 3 months after current
+
+        const wrapper = mount(Calendar, {
+          props: {
+            modelValue: currentDate,
+            min: minDate,
+            max: maxDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(currentDate.getFullYear());
+        expect(wrapper.vm.month).toBe(currentDate.getMonth());
+      });
+
+      it('should show modelValue month when modelValue equals current date and current is after max with both constraints', () => {
+        const currentDate = freshDate();
+        const minDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() - 3,
+          1,
+        ); // 3 months before current
+        const maxDate = new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth() - 1,
+          30,
+        ); // 1 month before current
+
+        const wrapper = mount(Calendar, {
+          props: {
+            modelValue: currentDate,
+            min: minDate,
+            max: maxDate,
+          },
+        });
+
+        expect(wrapper.vm.year).toBe(currentDate.getFullYear());
+        expect(wrapper.vm.month).toBe(currentDate.getMonth());
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Checklist

- [X] Test Coverage is 100% for the newly added code
- [x] Storybook stories are added/updated for the changed areas
- [x] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [X] Code is linted properly
- [X] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [X] Changelog.md updated on possible breaking (applicable to ent branch)



## Calendar Default Month Behavior

This update ensures that the calendar component respects **min/max bounds** when determining the default visible month.

- ✓ If the current date is **before the min value**, the picker will default to the **min month**.  
- ✓ If the current date is **after the max value**, the picker will default to the **max month**.  
- ✓ If the current date is **within the range**, it will show the **current month** as usual.  
-  **Exception:** If a `modelValue` is provided, the calendar will always open on the month of the selected value, and **min/max will not override it**.  
