### PR TITLE
ROS-494: Add a padding to count chip in OXD treeselect when inline label is visible

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+2026-03-03 - a15cfd91d588439872f49864cc912bc1628b45d9 - add a padding to count chip if there is inline label
+
 2025-02-24 - c7d1ea6631b4a04a34ea3e440b33417a15547b2c - components/src/core/components/Input/TreeSelect/TreeSelect.vue - Improve tree-select input to show selected values as much as possible (not limited to one)
 
 2025-02-16 - 03a24eacc0c10d61ba5c26b934ec433d93c6b386 - components/src/core/components/Input/TreeSelect/TreeSelect.vue - Show "All" when all the options are selected in the treeselect input

--- a/components/src/core/components/Input/TreeSelect/tree-select-input.scss
+++ b/components/src/core/components/Input/TreeSelect/tree-select-input.scss
@@ -137,3 +137,10 @@ td {
   overflow-x: auto;
   padding: $oxd-dropdown-dropdown-inner-padding;
 }
+
+:deep(
+    .oxd-select-text:has(> .oxd-select-text--has-inline-label)
+      .selected-count-chip
+  ) {
+  padding-top: 15px !important;
+}


### PR DESCRIPTION
## Checklist

- [x] Test Coverage is 100% for the newly added code
- [x] Storybook stories are added/updated for the changed areas
- [x] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [x] Code is linted properly
- [x] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [x] Changelog.md updated on possible breaking (applicable to ent branch)
