### PR TITLE
Add oxd-forum icon

### DIFF
--- a/components/src/core/components/Icon/icons.ts
+++ b/components/src/core/components/Icon/icons.ts
@@ -3047,6 +3047,11 @@ export const oxdDocumentText4: icon = {
 </svg>`,
 };
 
+export const oxdForum: icon = {
+  name: 'oxd-forum',
+  value: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" fill="none"><path style="fill:currentColor" d="M840-136q-8 0-15-3t-13-9l-92-92H320q-33 0-56.5-23.5T240-320v-40h440q33 0 56.5-23.5T760-440v-280h40q33 0 56.5 23.5T880-640v463q0 18-12 29.5T840-136ZM160-473l47-47h393v-280H160v327Zm-40 137q-16 0-28-11.5T80-377v-423q0-33 23.5-56.5T160-880h440q33 0 56.5 23.5T680-800v280q0 33-23.5 56.5T600-440H240l-92 92q-6 6-13 9t-15 3Zm40-184v-280 280Z"/></svg>`,
+};
+
 const icons: Icons = {
   'oxd-likes': oxdLikes,
   'oxd-birthday': oxdBirthday,
@@ -3373,6 +3378,7 @@ const icons: Icons = {
   'oxd-pay-structure': oxdPayStructure,
   'oxd-no-employees-found': oxdNoEmployeesFound,
   'oxd-document-text-4': oxdDocumentText4,
+  'oxd-forum': oxdForum,
 };
 
 export default icons;


### PR DESCRIPTION
Material Symbols "forum" (rounded, 24px). Follows the existing Material-symbols convention in this file: the 0 -960 960 960 viewBox is kept, width/height are dropped so the Icon component controls sizing, and the root fill is set to none with fill:currentColor declared on the path so the icon inherits color.

The downloaded SVG carried a ~5KB C2PA <metadata> block, which is stripped since icons are injected via v-html.

## Checklist

- [ ] Test Coverage is 100% for the newly added code
- [ ] Storybook stories are added/updated for the changed areas
- [ ] Components standards defined [in this document](https://docs.google.com/document/d/16_Nd3VxE_lTD9pVkONQ0egn7IiwyX1pVXZjzl-V4tU8/) are followed
- [ ] Code is linted properly
- [ ] Developer testing is done for the affected areas
- [ ] Package version updated (not applicable to ent branch)
- [ ] Changelog.md updated on possible breaking (applicable to ent branch)
